### PR TITLE
Parse the current global `$post` to detect Views

### DIFF
--- a/future/includes/class-gv-wrappers.php
+++ b/future/includes/class-gv-wrappers.php
@@ -28,7 +28,7 @@ class views {
 	 *
 	 * @param string|int|array|\GV\View|\WP_Post|null Anything goes.
 	 *
-	 * @return \GV\View|null The detected View.
+	 * @return \GV\View|\GV\View_Collection|null The detected View, Views, or null.
 	 */
 	public function get( $view = null ) {
 
@@ -39,14 +39,14 @@ class views {
 			return $this->get( $view->ID );
 		}
 
-		/** 
+		/**
 		 * By View ID.
 		 */
 		if ( is_numeric( $view ) ) {
 			return \GV\View::by_id( $view );
 		}
 
-		/** 
+		/**
 		 * By post object.
 		 */
 		if ( $view instanceof \WP_Post ) {
@@ -70,8 +70,21 @@ class views {
 
 			global $post;
 
-			if ( $post instanceof \WP_Post && $post->post_type == 'gravityview' ) {
-				return $this->get( $post );
+			if ( $post instanceof \WP_Post ) {
+				$views = \GV\View_Collection::from_post( $post );
+
+				// When no Views are found, return null.
+				if ( 0 === $views->count() ) {
+					return $this->view;
+				}
+
+				// When only one View is found, return a \GV\View.
+				if( 1 === $views->count() ) {
+					return $views->first();
+				}
+
+				// Otherwise, return a \GV\View_Collection.
+				return $views;
 			}
 
 			/**

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ __Developer Updates:__
 
 * Added: View blocks are also parsed when running `\GV\View_Collection::from_content()`
 * Added: New filter, to be used by Multiple Forms extension: `gravityview/view/get_entries/should_apply_legacy_join_is_approved_query_conditions`
+* Modified: `gravityview()->views->get()` now parses the content of the global `$post` object and will detect View shortcodes or blocks stored in the `$post->post_content`
+* Modified: `gravityview()->views->get()` now may return a `GV\View_Collection` object when it detects multiple Views in the content
 * Updated: HTML tags that had used `.hidden` now use the `.gv-hidden` CSS class to prevent potential conflicts with other plugins/themes
 
 = 2.17.1 on February 20, 2023 =


### PR DESCRIPTION
This is a big change, but I believe it's a Good Thing™. `gravityview()->views->get()` _should_ return all the Views available, not only if we're inside a CPT.

This modifies `get()` to parse the global `$post` object to also check for embedded shortcodes and blocks. The perfect lack of reliance on the global state is somewhat removed, but it's adding something we needed for GravityKit/Social-Sharing#28 and, I think, a lot of other page builder issues.

@mrcasual, please review this!