### PR TITLE
Make the Delete Link field an actual field

### DIFF
--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -1298,7 +1298,7 @@
 					vcfg.selectTemplateContinue( slugmatch );
 				}
 			} else {
-				// revert back to how things before before clicking "use a form preset"
+				// revert back to how things were before clicking "use a form preset"
 				vcfg.toggleViewTypeMetabox();
 				vcfg.showViewConfig();
 			}

--- a/future/includes/class-gv-entry.php
+++ b/future/includes/class-gv-entry.php
@@ -113,6 +113,17 @@ abstract class Entry {
 
 		$args = array();
 
+		/**
+		 * @filter `gravityview/entry_link/add_query_args` Modify whether to include passed $_GET parameters to the end of the url
+		 * @since 2.10
+		 * @param bool $add_query_params Whether to include passed $_GET parameters to the end of the Entry Link URL. Default: true.
+		 */
+		$add_query_args = apply_filters( 'gravityview/entry_link/add_query_args', true );
+
+		if ( $add_query_args ) {
+			$args = gv_get_query_args();
+		}
+
 		$view_id = is_null ( $view ) ? null : $view->ID;
 
 		$permalink = null;

--- a/future/includes/class-gv-entry.php
+++ b/future/includes/class-gv-entry.php
@@ -113,17 +113,6 @@ abstract class Entry {
 
 		$args = array();
 
-		/**
-		 * @filter `gravityview/entry_link/add_query_args` Modify whether to include passed $_GET parameters to the end of the url
-		 * @since 2.10
-		 * @param bool $add_query_params Whether to include passed $_GET parameters to the end of the Entry Link URL. Default: true.
-		 */
-		$add_query_args = apply_filters( 'gravityview/entry_link/add_query_args', true );
-
-		if ( $add_query_args ) {
-			$args = gv_get_query_args();
-		}
-
 		$view_id = is_null ( $view ) ? null : $view->ID;
 
 		$permalink = null;

--- a/includes/extensions/delete-entry/class-delete-entry-admin.php
+++ b/includes/extensions/delete-entry/class-delete-entry-admin.php
@@ -34,17 +34,8 @@ class GravityView_Delete_Entry_Admin {
 		// Add Delete Entry settings to Edit Entry Settings Metabox.
 		add_action( 'gravityview/metaboxes/edit_entry', array( $this, 'view_settings_edit_entry_metabox' ), 20 );
 
-		// For the Delete Entry Link, you don't want visible to all users.
-		add_filter( 'gravityview_field_visibility_caps', array( $this, 'modify_visibility_caps' ), 10, 5 );
-
-		// Modify the field options based on the name of the field type
-		add_filter( 'gravityview_template_delete_link_options', array( $this, 'delete_link_field_options' ), 10, 5 );
-
 		// Add Delete Entry settings to View Settings
 		add_action( 'gravityview/metaboxes/delete_entry', array( $this, 'view_settings_delete_entry_metabox' ), 7 );
-
-		// Add Delete Link as a default field, outside those set in the Gravity Form form
-		add_filter( 'gravityview_entry_default_fields', array( $this, 'add_default_field' ), 10, 3 );
 	}
 
 	/**
@@ -75,81 +66,6 @@ class GravityView_Delete_Entry_Admin {
 		GravityView_Render_Settings::render_setting_row( 'action_label_delete', $current_settings );
 	}
 
-	/**
-	 * Change wording for the Edit context to read Entry Creator
-	 *
-	 * @since 1.5.1
-	 * @since 2.9.2 Moved here from GravityView_Delete_Entry
-	 *
-	 * @param array $visibility_caps Array of capabilities to display in field dropdown.
-	 * @param string $field_type Type of field options to render (`field` or `widget`)
-	 * @param string $template_id Table slug
-	 * @param float $field_id GF Field ID - Example: `3`, `5.2`, `entry_link`, `created_by`
-	 * @param string $context What context are we in? Example: `single` or `directory`
-	 * @param string $input_type (textarea, list, select, etc.)
-	 *
-	 * @return array                   Array of field options with `label`, `value`, `type`, `default` keys
-	 */
-	public function modify_visibility_caps( $visibility_caps = array(), $template_id = '', $field_id = '', $context = '', $input_type = '' ) {
-
-		$caps = $visibility_caps;
-
-		// If we're configuring fields in the edit context, we want a limited selection
-		if ( $field_id === 'delete_link' ) {
-
-			// Remove other built-in caps.
-			unset( $caps['publish_posts'], $caps['gravityforms_view_entries'], $caps['delete_others_posts'] );
-
-			$caps['read'] = _x( 'Entry Creator', 'User capability', 'gk-gravityview' );
-		}
-
-		return $caps;
-	}
-
-	/**
-	 * Add "Delete Link Text" setting to the edit_link field settings
-	 *
-	 * @since 1.5.1
-	 * @since 2.9.2 Moved here from GravityView_Delete_Entry
-	 *
-	 * @param array $field_options
-	 * @param string $template_id
-	 * @param string $field_id
-	 * @param string $context
-	 * @param string $input_type
-	 *
-	 * @return array $field_options, with "Delete Link Text" and "Allow the following users to delete the entry:" field options.
-	 */
-	public function delete_link_field_options( $field_options, $template_id, $field_id, $context, $input_type ) {
-
-		// Always a link, never a filter
-		unset( $field_options['show_as_link'], $field_options['search_filter'] );
-
-		// Delete Entry link should only appear to visitors capable of editing entries
-		unset( $field_options['only_loggedin'], $field_options['only_loggedin_cap'] );
-
-		$add_option['delete_link'] = array(
-			'type'       => 'text',
-			'label'      => __( 'Delete Link Text', 'gk-gravityview' ),
-			'desc'       => null,
-			'value'      => __( 'Delete Entry', 'gk-gravityview' ),
-			'merge_tags' => true,
-		);
-
-		$field_options['allow_edit_cap'] = array(
-			'type'    => 'select',
-			'label'   => __( 'Allow the following users to delete the entry:', 'gk-gravityview' ),
-			'choices' => GravityView_Render_Settings::get_cap_choices( $template_id, $field_id, $context, $input_type ),
-			'tooltip' => 'allow_edit_cap',
-			'class'   => 'widefat',
-			'value'   => 'read', // Default: entry creator
-			'group'   => 'visibility',
-			'priority' => 100,
-		);
-
-		return array_merge( $add_option, $field_options );
-	}
-
 
 	/**
 	 * Add Delete Entry Link to the Add Field dialog
@@ -170,6 +86,7 @@ class GravityView_Delete_Entry_Admin {
 			'input_type'    => 'delete_link',
 			'field_options' => null,
 			'icon'          => 'dashicons-trash',
+			'group'         => 'gravityview',
 		);
 
 		return $available_fields;
@@ -190,29 +107,4 @@ class GravityView_Delete_Entry_Admin {
 
 	}
 
-	/**
-	 * Add Edit Link as a default field, outside those set in the Gravity Form form
-	 *
-	 * @since 1.5.1
-	 * @since 2.9.2 Moved here from GravityView_Delete_Entry
-	 *
-	 * @param array $entry_default_fields Existing fields
-	 * @param string|array $form form_ID or form object
-	 * @param string $zone Either 'single', 'directory', 'edit', 'header', 'footer'
-	 *
-	 * @return array
-	 */
-	public function add_default_field( $entry_default_fields, $form = array(), $zone = '' ) {
-
-		if ( 'edit' !== $zone ) {
-			$entry_default_fields['delete_link'] = array(
-				'label' => __( 'Delete Entry', 'gk-gravityview' ),
-				'type'  => 'delete_link',
-				'desc'  => __( 'A link to delete the entry. Respects the Delete Entry permissions.', 'gk-gravityview' ),
-				'icon'  => 'dashicons-trash',
-			);
-		}
-
-		return $entry_default_fields;
-	}
 }

--- a/includes/extensions/delete-entry/class-delete-entry.php
+++ b/includes/extensions/delete-entry/class-delete-entry.php
@@ -55,6 +55,8 @@ final class GravityView_Delete_Entry {
 			$this->load_components( 'admin' );
 		}
 
+		require_once trailingslashit( self::$file ) . 'class-gravityview-field-delete-link.php';
+
 		$this->add_hooks();
 	}
 

--- a/includes/extensions/delete-entry/class-gravityview-field-delete-link.php
+++ b/includes/extensions/delete-entry/class-gravityview-field-delete-link.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @file class-gravityview-field-delete-link.php
+ * @package GravityView
+ * @subpackage includes\extensions\delete-entry\fields
+ */
+
+/**
+ * Add custom options for delete_link fields
+ */
+class GravityView_Field_Delete_Link extends GravityView_Field {
+
+	/** @inheritDoc  */
+	var $name = 'delete_link';
+
+	/** @inheritDoc  */
+	var $contexts = array( 'multiple', 'single' );
+
+	/** @inheritDoc  */
+	var $is_sortable = false;
+
+	/** @inheritDoc  */
+	var $is_searchable = false;
+
+	/** @inheritDoc  */
+	var $group = 'gravityview';
+
+	/** @inheritDoc  */
+	var $icon = 'dashicons-trash';
+
+	public function __construct() {
+		$this->label = esc_html__( 'Delete Entry', 'gk-gravityview' );
+		$this->description = esc_html__( 'A link to delete the entry. Respects the Delete Entry permissions.', 'gk-gravityview' );
+
+		$this->add_hooks();
+
+		parent::__construct();
+	}
+
+	/**
+	 * Add hooks for this field type.
+	 *
+	 * @return void
+	 */
+	public function add_hooks() {
+		// For the Delete Entry Link, you don't want visible to all users.
+		add_filter( 'gravityview_field_visibility_caps', array( $this, 'modify_visibility_caps' ), 10, 5 );
+
+		// Add Delete Link as a default field, outside those set in the Gravity Form form
+		add_filter( 'gravityview_entry_default_fields', array( $this, 'add_default_field' ), 10, 3 );
+	}
+
+	/**
+	 * Change wording for the Edit context to read Entry Creator
+	 *
+	 * @since 1.5.1
+	 * @since 2.9.2 Moved here from GravityView_Delete_Entry
+	 *
+	 * @param array $visibility_caps Array of capabilities to display in field dropdown.
+	 * @param string $field_type Type of field options to render (`field` or `widget`)
+	 * @param string $template_id Table slug
+	 * @param float $field_id GF Field ID - Example: `3`, `5.2`, `entry_link`, `created_by`
+	 * @param string $context What context are we in? Example: `single` or `directory`
+	 * @param string $input_type (textarea, list, select, etc.)
+	 *
+	 * @return array                   Array of field options with `label`, `value`, `type`, `default` keys
+	 */
+	public function modify_visibility_caps( $visibility_caps = array(), $template_id = '', $field_id = '', $context = '', $input_type = '' ) {
+
+		if ( $field_id !== $this->name ) {
+			return $visibility_caps;
+		}
+
+		$caps = $visibility_caps;
+
+		// If we're configuring fields in the edit context, we want a limited selection. Remove other built-in caps.
+		unset( $caps['publish_posts'], $caps['gravityforms_view_entries'], $caps['delete_others_posts'] );
+
+		$caps['read'] = _x( 'Entry Creator', 'User capability', 'gk-gravityview' );
+
+		return $caps;
+	}
+
+	/**
+	 * Add "Delete Link Text" setting to the edit_link field settings
+	 *
+	 * @since 1.5.1
+	 * @since 2.9.2 Moved here from GravityView_Delete_Entry
+	 * @since TODO Moved to own field class.
+	 *
+	 * @param array $field_options
+	 * @param string $template_id
+	 * @param string $field_id
+	 * @param string $context
+	 * @param string $input_type
+	 *
+	 * @return array $field_options, with "Delete Link Text" and "Allow the following users to delete the entry:" field options.
+	 */
+	public function field_options( $field_options, $template_id, $field_id, $context, $input_type, $form_id ) {
+
+		// Always a link, never a filter
+		unset( $field_options['show_as_link'], $field_options['search_filter'] );
+
+		// Delete Entry link should only appear to visitors capable of editing entries
+		unset( $field_options['only_loggedin'], $field_options['only_loggedin_cap'] );
+
+		$add_option['delete_link'] = array(
+			'type'       => 'text',
+			'label'      => __( 'Delete Link Text', 'gk-gravityview' ),
+			'desc'       => null,
+			'value'      => __( 'Delete Entry', 'gk-gravityview' ),
+			'merge_tags' => true,
+		);
+
+		$field_options['allow_edit_cap'] = array(
+			'type'    => 'select',
+			'label'   => __( 'Allow the following users to delete the entry:', 'gk-gravityview' ),
+			'choices' => GravityView_Render_Settings::get_cap_choices( $template_id, $field_id, $context, $input_type ),
+			'tooltip' => 'allow_edit_cap',
+			'class'   => 'widefat',
+			'value'   => 'read', // Default: entry creator
+			'group'   => 'visibility',
+			'priority' => 100,
+		);
+
+		return array_merge( $add_option, $field_options );
+	}
+
+}
+
+new GravityView_Field_Delete_Link;

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,13 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+__Developer Notes:__
+
+* Added: `GravityView_Field_Delete_Link` class to render the Delete Entry link instead of relying on filtering
+	- `delete_link` will now be properly returned in the `GravityView_Fields::get_all('gravityview');` response
+
 = 2.17.8 on May 16, 2023 =
 
 * Improved: Performance when using Gravity Forms 2.6.9 or older


### PR DESCRIPTION
This means that `delete_link` will now be properly returned in the `GravityView_Fields::get_all('gravityview');` response.