### PR TITLE
Cache DB queries used to get all entries

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,14 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= 2.18.2 [unreleased] =
+
+* Fixed: Performance issue introduced in 2.18.1
+
+__Developer Notes:__
+
+* Added: `gk/gravityview/view/entries/cache` filter to provide control over the caching of DB queries
+
 = 2.18.1 on June 20, 2023 =
 
 * Fixed: PHP warning message that appeared when attempting to edit a View

--- a/tests/unit-tests/GravityView_Field_Test.php
+++ b/tests/unit-tests/GravityView_Field_Test.php
@@ -115,6 +115,8 @@ class GravityView_Field_Test extends GV_UnitTestCase {
 	 * https://github.com/gravityview/GravityView/issues/1223
 	 */
 	function test_GravityView_Field_Other_Entries_get_entries() {
+		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+
 		$form = $this->factory->form->import_and_get( 'complete.json' );
 		$post = $this->factory->view->create_and_get( array(
 			'form_id' => $form['id'],
@@ -220,6 +222,8 @@ class GravityView_Field_Test extends GV_UnitTestCase {
 		$entries = $field->field->get_entries( $context );
 		$this->assertCount( 1, $entries );
 		$this->assertEquals( $valid_date_entry->ID, $entries[0]->ID );
+
+		remove_all_filters( 'gk/gravityview/view/entries/cache' );
 	}
 
 	function test_GravityView_Field_Sequence() {
@@ -308,6 +312,8 @@ class GravityView_Field_Test extends GV_UnitTestCase {
 	}
 
 	function test_GravityView_Field_Sequence_single() {
+		add_filter( 'gk/gravityview/view/entries/cache', $disable_cache_filter = '__return_false' );
+
 		$form = $this->factory->form->import_and_get( 'simple.json' );
 		$post = $this->factory->view->create_and_get( array(
 			'form_id' => $form['id'],
@@ -354,6 +360,8 @@ class GravityView_Field_Test extends GV_UnitTestCase {
 		$field->reverse = true;
 
 		$this->assertEquals( 1, $field->field->get_sequence( $context ) );
+
+		remove_all_filters( 'gk/gravityview/view/entries/cache' );
 	}
 
 	function test_GravityView_Field_Unsubscribe_render_permissions() {

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -1811,6 +1811,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 
         add_filter( 'gravityview/view/anchor_id', '__return_false' );
         add_filter( 'gravityview/widget/search/append_view_id_anchor', '__return_false' );
+		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
 
 		gravityview()->request = new \GV\Mock_Request();
 		gravityview()->request->returns['is_view'] = $view;
@@ -1988,6 +1989,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 
 		remove_all_filters( 'gravityview/view/anchor_id' );
 		remove_all_filters( 'gravityview/widget/search/append_view_id_anchor' );
+		remove_all_filters( 'gk/gravityview/view/entries/cache' );
 	}
 
 	/**
@@ -2168,6 +2170,8 @@ class GVFuture_Test extends GV_UnitTestCase {
 	public function test_frontend_widgets() {
 		$form = $this->factory->form->import_and_get( 'complete.json' );
 
+		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+
 		global $post;
 
 		$settings = \GV\View_Settings::defaults();
@@ -2244,6 +2248,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 
 		remove_all_filters( 'gravityview/view/anchor_id' );
 		remove_all_filters( 'gravityview/widget/search/append_view_id_anchor' );
+		remove_all_filters( 'gk/gravityview/view/entries/cache' );
 	}
 
 	/**

--- a/tests/unit-tests/GravityView_Joins_Test.php
+++ b/tests/unit-tests/GravityView_Joins_Test.php
@@ -286,6 +286,8 @@ class GravityView_Joins_Test extends GV_UnitTestCase {
 	}
 
 	public function test_joins_with_approves() {
+		add_filter('gk/gravityview/view/entries/cache', '__return_false');
+
 		$this->_reset_context();
 
 		if ( ! gravityview()->plugin->supports( \GV\Plugin::FEATURE_JOINS ) ) {
@@ -372,6 +374,8 @@ class GravityView_Joins_Test extends GV_UnitTestCase {
 		$this->assertCount( 0, $entries->all() );
 
 		$this->_reset_context();
+
+		remove_all_filters( 'gk/gravityview/view/entries/cache' );
 	}
 
 	public function test_legacy_template_table_joins() {


### PR DESCRIPTION
This implements caching for repetitive DB queries to optimize speed, particularly for costly queries involving joins against the `wp_gf_entry` table containing millions of records.