### PR TITLE
Optimize and improve the View editor

### DIFF
--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -396,11 +396,11 @@
 		toggleDisabled: function ( $one, $two ) {
 
 			if ( $one.is( ':checked' ) ) {
-				$two.attr( 'disabled', true );
+				$two.prop( 'disabled', true );
 			}
 
-			if ( $two.filter(':checked').length > 0 ) {
-				$one.attr( 'disabled', true );
+			if ( $two.is(':checked').length > 0 ) {
+				$one.prop( 'disabled', true );
 			}
 		},
 

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -1699,11 +1699,11 @@
 		init_tooltips: function (el) {
 
 			// Already initialized.
-			if ( 0 === $( el || '.gv-add-field' ).not( ':ui-tooltip' ).length ) {
+			if ( 0 === $( el || '.gv-add-field', '#post' ).not( ':ui-tooltip' ).length ) {
 				return;
 			}
 
-			$( el || ".gv-add-field" ).gvTooltip( {
+			$( el || ".gv-add-field", '#post' ).gvTooltip( {
 				show:    150,
 				hide:    200,
 				content: function () {

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -181,8 +181,6 @@
 				// Update checkbox visibility when having dependency checkboxes
 				.on( 'gravityview/loaded', vcfg.toggleCheckboxes )
 
-				.on( 'change', ".gv-setting-list, #gravityview_settings, .gv-dialog-options", vcfg.toggleCheckboxes )
-
 				.on( 'change', "#gravityview_settings", vcfg.zebraStripeSettings )
 
 				.on( 'click', '.gv-field-details--toggle', function( e ) {
@@ -218,6 +216,11 @@
 				.on( 'gravityview/loaded gravityview/tabs-ready gravityview/field-added gravityview/field-removed gravityview/all-fields-removed gravityview/show-as-entry gravityview/view-config-updated', vcfg.toggleRemoveAllFields )
 
 				.on( 'search keydown keyup', '.gv-field-filter-form input:visible', vcfg.setupFieldFilters )
+
+				// Only start tracking changes after the View is loaded to prevent this from being run multiple times.
+				.on( 'gravityview/loaded', function() {
+					$(".gv-setting-list, #gravityview_settings, .gv-dialog-options").on('change', vcfg.toggleCheckboxes );
+				})
 
 				.on( 'focus', '.gv-add-field', function( e ) {
 					$( this ).parent('.gv-fields').addClass( 'trigger--hover' );

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -420,7 +420,8 @@
 			$parent
 				.find( '[data-' + data_attr + ']' )
 				.each( function ()  {
-					var requires = $( this ).data( data_attr ),
+					var $this = $( this ),
+						requires = $this.data( data_attr ),
 						requires_array = requires.split('='),
 						requires_name = requires_array[0],
 						requires_value = requires_array[1];
@@ -429,15 +430,15 @@
 
 					if ( $input.is(':checkbox') ) {
 						if ( reverse_logic ) {
-							$(this).toggle( $input.not(':checked') );
+							$this.toggle( $input.not(':checked') );
 						} else {
-							$(this).toggle( $input.is(':checked') );
+							$this.toggle( $input.is(':checked') );
 						}
 					} else if ( requires_value !== undefined ) {
 						if ( reverse_logic ) {
-							$(this).toggle( $input.val() !== requires_value );
+							$this.toggle( $input.val() !== requires_value );
 						} else {
-							$(this).toggle( $input.val() === requires_value );
+							$this.toggle( $input.val() === requires_value );
 						}
 					}
 				});

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -415,7 +415,7 @@
 		 */
 		toggleRequired: function( currentTarget, data_attr, reverse_logic ) {
 
-			var $parent = $( currentTarget );
+			var $parent = $( currentTarget, '#post' );
 
 			$parent
 				.find( '[data-' + data_attr + ']' )

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -2750,9 +2750,9 @@
 				viewConfiguration.init_droppables( ui.panel );
 
 				/** @since 2.14.1 */
-				$( 'body' ).trigger( 'gravityview/tab-ready', ui.panel );
-
-				$( 'body' ).trigger( 'gravityview/tabs-ready' );
+				$( 'body' )
+					.trigger( 'gravityview/tab-ready', ui.panel )
+					.trigger( 'gravityview/tabs-ready' );
 			},
 			activate: function ( event, ui ) {
 				// When the tab is activated, set a new cookie

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -379,10 +379,10 @@
 			var $parent = $( target ).is( '.gv-fields' ) ? $( target ) : $( target ).parents( '.gv-fields' );
 
 			// "Link to Post" should hide when "Link to single entry" is checked
-			viewConfiguration.toggleDisabled( $( 'input:checkbox[name*=link_to_]', $parent ), $( 'input:checkbox[name*=show_as_link]', $parent ) );
+			viewConfiguration.toggleDisabled( $( 'input[type=checkbox][name*=link_to_]', $parent ), $( 'input[type=checkbox][name*=show_as_link]', $parent ) );
 
 			// "Make Phone Number Clickable" should hide when "Link to single entry" is checked
-			viewConfiguration.toggleDisabled( $( 'input:checkbox[name*=link_phone]', $parent ), $( 'input:checkbox[name*=show_as_link]', $parent ) );
+			viewConfiguration.toggleDisabled( $( 'input[type=checkbox][name*=link_phone]', $parent ), $( 'input[type=checkbox][name*=show_as_link]', $parent ) );
 		},
 
 		/**
@@ -428,7 +428,7 @@
 
 					var $input = $parent.find('[name$="[' + requires_name + ']"]').filter(':input');
 
-					if ( $input.is(':checkbox') ) {
+					if ( $input.is('[type=checkbox]') ) {
 						if ( reverse_logic ) {
 							$this.toggle( $input.not(':checked') );
 						} else {
@@ -2295,7 +2295,7 @@
 			vcfg.updateVisibilitySettings( e, true );
 
 			// Toggle checkbox when changing field visibility
-			$( 'body' ).on( 'change', '.gv-fields input:checkbox', vcfg.updateVisibilitySettings );
+			$( 'body' ).on( 'change', '.gv-fields input[type=checkbox]', vcfg.updateVisibilitySettings );
 
 			var buttons = [
 				{
@@ -2327,7 +2327,7 @@
 
 			$( ".gv-setting-list", $parent ).trigger( 'change' );
 
-			$( 'input:checkbox', $parent ).attr( 'disabled', null );
+			$( 'input[type=checkbox]', $parent ).attr( 'disabled', null );
 
 			vcfg.setUnsavedChanges( true );
 		},

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -216,7 +216,7 @@
 
 				// Only start tracking changes after the View is loaded to prevent this from being run multiple times.
 				.on( 'gravityview/loaded', function() {
-					$(".gv-setting-list, #gravityview_settings, .gv-dialog-options").on('change', vcfg.toggleCheckboxes );
+					$("#gravityview_settings").on('change', vcfg.toggleCheckboxes );
 				})
 
 				.on( 'focus', '.gv-add-field', function( e ) {

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -378,6 +378,10 @@
 
 			var $parent = $( target ).is( '.gv-fields' ) ? $( target ) : $( target ).parents( '.gv-fields' );
 
+			if ( ! $parent.length ) {
+				return;
+			}
+
 			// "Link to Post" should hide when "Link to single entry" is checked
 			viewConfiguration.toggleDisabled( $( 'input[type=checkbox][name*=link_to_]', $parent ), $( 'input[type=checkbox][name*=show_as_link]', $parent ) );
 

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -216,7 +216,7 @@
 
 				// Only start tracking changes after the View is loaded to prevent this from being run multiple times.
 				.on( 'gravityview/loaded', function() {
-					$("#gravityview_settings").on('change', vcfg.toggleCheckboxes );
+					$(".gv-setting-list, #gravityview_settings, .gv-dialog-options", '#post' ).on('change', vcfg.toggleCheckboxes );
 				})
 
 				.on( 'focus', '.gv-add-field', function( e ) {

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -395,6 +395,10 @@
 		 */
 		toggleDisabled: function ( $one, $two ) {
 
+			if ( $one.length === 0 || $two.length === 0 ) {
+				return;
+			}
+
 			if ( $one.is( ':checked' ) ) {
 				$two.prop( 'disabled', true );
 			}

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -426,7 +426,7 @@
 						requires_name = requires_array[0],
 						requires_value = requires_array[1];
 
-					var $input = $parent.find(':input[name$="[' + requires_name + ']"]');
+					var $input = $parent.find('[name$="[' + requires_name + ']"]').filter(':input');
 
 					if ( $input.is(':checkbox') ) {
 						if ( reverse_logic ) {
@@ -2425,7 +2425,7 @@
 				serialized_data = $post.data( 'gv-serialized' );
 			} else {
 				// Get all the fields where the `name` attribute start with `fields`
-				$fields = $post.find( ':input[name^=fields]' );
+				$fields = $post.find( '[name^=fields]' ).filter(':input');
 
 				// Serialize the data
 				serialized_data = $fields.serialize();
@@ -2437,7 +2437,7 @@
 			}
 
 			// Also exclude these fields from $_POST...
-			$post.find( ':input[name=gv_fields]' ).prop( 'disabled', true );
+			$post.find( '[name=gv_fields]' ).filter(':input').prop( 'disabled', true );
 
 			// ...instead, add a single field to the form that contains all the data.
 			$post.append( $( '<input/>', {

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -178,9 +178,6 @@
 				// Double-clicking a field/widget label opens settings
 				.on( 'dblclick', ".gv-fields:not(.gv-nonexistent-form-field)", vcfg.openFieldSettings )
 
-				// Update checkbox visibility when having dependency checkboxes
-				.on( 'gravityview/loaded', vcfg.toggleCheckboxes )
-
 				.on( 'change', "#gravityview_settings", vcfg.zebraStripeSettings )
 
 				.on( 'click', '.gv-field-details--toggle', function( e ) {

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -2710,7 +2710,7 @@
 
 	};  // end viewGeneralSettings object
 
-	jQuery(function ( $ ) {
+	jQuery( function ( $ ) {
 
 		// title placeholder
 		$( '#title-prompt-text' ).text( gvGlobals.label_viewname );
@@ -2765,13 +2765,14 @@
 			}
 		} );
 
+		// Expose globally methods to initialize/destroy tooltips and to display dialog window
+		window.gvAdminActions = {
+			initTooltips: viewConfiguration.init_tooltips,
+			removeTooltips: viewConfiguration.remove_tooltips,
+			showDialog: viewConfiguration.showDialog
+		};
+
 		$( 'body' ).trigger( 'gravityview/loaded' );
 	} );
 
-	// Expose globally methods to initialize/destroy tooltips and to display dialog window
-	window.gvAdminActions = {
-		initTooltips: viewConfiguration.init_tooltips,
-		removeTooltips: viewConfiguration.remove_tooltips,
-		showDialog: viewConfiguration.showDialog
-	};
 }(jQuery));

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -216,8 +216,10 @@
 
 				// Only start tracking changes after the View is loaded to prevent this from being run multiple times.
 				.on( 'gravityview/loaded', function() {
-					$(".gv-setting-list, #gravityview_settings, .gv-dialog-options", '#post' ).on('change', vcfg.toggleCheckboxes );
+					$(".gv-setting-list, #gravityview_settings" ).on('change', vcfg.toggleCheckboxes );
 				})
+
+				.on( 'change', ".gv-dialog-options", vcfg.toggleCheckboxes )
 
 				.on( 'focus', '.gv-add-field', function( e ) {
 					$( this ).parent('.gv-fields').addClass( 'trigger--hover' );
@@ -408,7 +410,7 @@
 				return;
 			}
 
-			if ( $two.is(':checked').length > 0 ) {
+			if ( $two.is(':checked') ) {
 				$one.prop( 'disabled', true );
 			}
 		},

--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -405,6 +405,7 @@
 
 			if ( $one.is( ':checked' ) ) {
 				$two.prop( 'disabled', true );
+				return;
 			}
 
 			if ( $two.is(':checked').length > 0 ) {

--- a/future/includes/class-gv-settings-plugin.php
+++ b/future/includes/class-gv-settings-plugin.php
@@ -326,205 +326,39 @@ class Plugin_Settings {
 	 * @return void
 	 */
 	public function maybe_save_app_settings() {
-		if ( $this->is_save_postback() ) {
-			if ( ! \GVCommon::has_cap( 'gravityview_edit_settings' ) ) {
-				$_POST = []; // If you don't reset the $_POST array, it *looks* like the settings were changed, but they weren't
-				\GFCommon::add_error_message( __( 'You don\'t have the ability to edit plugin settings.', 'gk-gravityview' ) );
-
-				return;
-			}
+		if ( ! $this->is_save_postback() ) {
+			return;
 		}
-	}
 
-	/*
-	 * @TODO Reimplement elsewhere.
-	 */
-	private function _uninstall_warning_message() {
-		$heading = esc_html__( 'If you delete then re-install GravityView, it will be like installing GravityView for the first time.', 'gk-gravityview' );
-		$message = esc_html__( 'Delete all Views, GravityView entry approval status, GravityView-generated entry notes (including approval and entry creator changes), and GravityView plugin settings.', 'gk-gravityview' );
+		if ( \GVCommon::has_cap( 'gravityview_edit_settings' ) ) {
+			return;
+		}
 
-		return sprintf( '<h4>%s</h4><p>%s</p>', $heading, $message );
+		$_POST = []; // If you don't reset the $_POST array, it *looks* like the settings were changed, but they weren't
+		\GFCommon::add_error_message( __( 'You don\'t have the ability to edit plugin settings.', 'gk-gravityview' ) );
 	}
 
 	/**
-	 * @TODO Reimplement elsewhere.
+	 * @TODO Reimplement elsewhere. Keeping the strings from the form here, for now, so that translations are not lost.
+	 * @internal
 	 */
-	private function _get_uninstall_reasons() {
-		$reasons = [
-			'will-continue'  => [
-				'label' => esc_html__( 'I am going to continue using GravityView', 'gk-gravityview' ),
-			],
-			'no-longer-need' => [
-				'label' => esc_html__( 'I no longer need GravityView', 'gk-gravityview' ),
-			],
-			'doesnt-work'    => [
-				'label' => esc_html__( 'The plugin doesn\'t work', 'gk-gravityview' ),
-			],
-			'found-other'    => [
-				'label'    => esc_html__( 'I found a better plugin', 'gk-gravityview' ),
-				'followup' => esc_attr__( 'What plugin you are using, and why?', 'gk-gravityview' ),
-			],
-			'other'          => [
-				'label' => esc_html__( 'Other', 'gk-gravityview' ),
-			],
-		];
-
-		shuffle( $reasons );
-
-		return $reasons;
-	}
-
-	/**
-	 * @TODO Reimplement elsewhere.
-	 */
-	private function _uninstall_form() {
-		ob_start();
-
-		$user = wp_get_current_user();
-		?>
-		<style>
-            #gv-reason-details {
-                min-height: 100px;
-            }
-
-            .number-scale label {
-                border: 1px solid #cccccc;
-                padding: .5em .75em;
-                margin: .1em;
-            }
-
-            #gv-uninstall-thanks p {
-                font-size: 1.2em;
-            }
-
-            .scale-description ul {
-                margin-bottom: 0;
-                padding-bottom: 0;
-            }
-
-            .scale-description p.description {
-                margin-top: 0 !important;
-                padding-top: 0 !important;
-            }
-
-            .gv-form-field-wrapper {
-                margin-top: 30px;
-            }
-		</style>
-
-		<?php
-		if ( gravityview()->plugin->is_GF_25() ) {
-			$uninstall_title = esc_html__( 'Uninstall GravityView', 'gk-gravityview' );
-
-			echo <<<HTML
-<div class="gform-settings-panel">
-    <header class="gform-settings-panel__header">
-        <h4 class="gform-settings-panel__title">{$uninstall_title}</h4>
-    </header>
-    <div class="gform-settings-panel__content" style="padding: 0 1rem 1.25rem">
-
-HTML;
-		} else {
-			echo '<div class="gv-uninstall-form-wrapper" style="font-size: 110%; padding: 15px 0;">';
-		}
-		?>
-		<script>
-			jQuery( function ( $ ) {
-				$( '#gv-uninstall-feedback' ).on( 'change', function ( e ) {
-
-					if ( !$( e.target ).is( ':input' ) ) {
-						return;
-					}
-					var $textarea = $( '.gv-followup' ).find( 'textarea' );
-					var followup_text = $( e.target ).attr( 'data-followup' );
-					if ( !followup_text ) {
-						followup_text = $textarea.attr( 'data-default' );
-					}
-
-					$textarea.attr( 'placeholder', followup_text );
-
-				} ).on( 'submit', function ( e ) {
-					e.preventDefault();
-
-					$.post( $( this ).attr( 'action' ), $( this ).serialize() )
-						.done( function ( data ) {
-							if ( 'success' !== data.status ) {
-								gv_feedback_append_error_message();
-							} else {
-								$( '#gv-uninstall-thanks' ).fadeIn();
-							}
-						} )
-						.fail( function ( data ) {
-							gv_feedback_append_error_message();
-						} )
-						.always( function () {
-							$( e.target ).remove();
-						} );
-
-					return false;
-				} );
-
-				function gv_feedback_append_error_message() {
-					$( '#gv-uninstall-thanks' ).append( '<div class="notice error">' + <?php echo json_encode( esc_html( __( 'There was an error sharing your feedback. Sorry! Please email us at support@gravitykit.com', 'gk-gravityview' ) ) ) ?> +'</div>' );
-				}
-			} );
-		</script>
-
-		<form id="gv-uninstall-feedback" method="post" action="https://hooks.zapier.com/hooks/catch/28670/6haevn/">
-			<h2><?php esc_html_e( 'Why did you uninstall GravityView?', 'gk-gravityview' ); ?></h2>
-			<ul>
-				<?php
-				$reasons = $this->get_uninstall_reasons();
-				foreach ( $reasons as $reason ) {
-					printf( '<li><label><input name="reason" type="radio" value="other" data-followup="%s"> %s</label></li>', Arr::get( $reason, 'followup' ), Arr::get( $reason, 'label' ) );
-				}
-				?>
-			</ul>
-			<div class="gv-followup widefat">
-				<p><strong><label for="gv-reason-details"><?php esc_html_e( 'Comments', 'gk-gravityview' ); ?></label></strong></p>
-				<textarea id="gv-reason-details" name="reason_details" data-default="<?php esc_attr_e( 'Please share your thoughts about GravityView', 'gk-gravityview' ) ?>" placeholder="<?php esc_attr_e( 'Please share your thoughts about GravityView', 'gk-gravityview' ); ?>" class="large-text"></textarea>
-			</div>
-			<div class="scale-description">
-				<p><strong><?php esc_html_e( 'How likely are you to recommend GravityView?', 'gk-gravityview' ); ?></strong></p>
-				<ul class="inline">
-					<?php
-					$i = 0;
-					while ( $i < 11 ) {
-						echo '<li class="inline number-scale"><label><input name="likely_to_refer" id="likely_to_refer_' . $i . '" value="' . $i . '" type="radio"> ' . $i . '</label></li>';
-						$i++;
-					}
-					?>
-				</ul>
-				<p class="description"><?php printf( esc_html_x( '%s ("Not at all likely") to %s ("Extremely likely")', 'A scale from 0 (bad) to 10 (good)', 'gk-gravityview' ), '<label for="likely_to_refer_0"><code>0</code></label>', '<label for="likely_to_refer_10"><code>10</code></label>' ); ?></p>
-			</div>
-
-			<div class="gv-form-field-wrapper">
-				<label><input type="checkbox" class="checkbox" name="follow_up_with_me" value="1" /> <?php esc_html_e( 'Please follow up with me about my feedback', 'gk-gravityview' ); ?></label>
-			</div>
-
-			<div class="submit">
-				<input type="hidden" name="siteurl" value="<?php echo esc_url( get_bloginfo( 'url' ) ); ?>" />
-				<input type="hidden" name="email" value="<?php echo esc_attr( $user->user_email ); ?>" />
-				<input type="hidden" name="display_name" value="<?php echo esc_attr( $user->display_name ); ?>" />
-				<input type="submit" value="<?php esc_html_e( 'Send Us Your Feedback', 'gk-gravityview' ); ?>" class="button button-primary primary button-hero" />
-			</div>
-		</form>
-
-		<div id="gv-uninstall-thanks" class="<?php echo ( gravityview()->plugin->is_GF_25() ) ? 'notice-large' : 'notice notice-large notice-updated below-h2'; ?>" style="display:none;">
-			<h3 class="notice-title"><?php esc_html_e( 'Thank you for using GravityView!', 'gk-gravityview' ); ?></h3>
-			<p><?php echo gravityview_get_floaty(); ?>
-				<?php echo make_clickable( esc_html__( 'Your feedback helps us improve GravityView. If you have any questions or comments, email us: support@gravitykit.com', 'gk-gravityview' ) ); ?>
-			</p>
-			<div class="wp-clearfix"></div>
-		</div>
-		</div>
-		<?php
-		if ( gravityview()->plugin->is_GF_25() ) {
-			echo '</div>';
-		}
-
-		$form = ob_get_clean();
-
-		return $form;
+	private function _uninstall_form_strings() {
+		__( 'Uninstall GravityView', 'gk-gravityview' );
+		__( 'There was an error sharing your feedback. Sorry! Please email us at support@gravitykit.com', 'gk-gravityview' );
+		__( 'Please share your thoughts about GravityView', 'gk-gravityview' );
+		__( 'Please follow up with me about my feedback', 'gk-gravityview' );
+		__( 'How likely are you to recommend GravityView?', 'gk-gravityview' );
+		__( 'Send Us Your Feedback', 'gk-gravityview' );
+		__( 'Thank you for using GravityView!', 'gk-gravityview' );
+		__( 'Your feedback helps us improve GravityView. If you have any questions or comments, email us: support@gravitykit.com', 'gk-gravityview' );
+		__( 'If you delete then re-install GravityView, it will be like installing GravityView for the first time.', 'gk-gravityview' );
+		__( 'Delete all Views, GravityView entry approval status, GravityView-generated entry notes (including approval and entry creator changes), and GravityView plugin settings.', 'gk-gravityview' );
+		__( 'I am going to continue using GravityView', 'gk-gravityview' );
+		__( 'I no longer need GravityView', 'gk-gravityview' );
+		__( 'The plugin doesn\'t work', 'gk-gravityview' );
+		__( 'I found a better plugin', 'gk-gravityview' );
+		__( 'What plugin you are using, and why?', 'gk-gravityview' );
+		__( 'Other', 'gk-gravityview' );
+		_x( '%s ("Not at all likely") to %s ("Extremely likely")', 'A scale from 0 (bad) to 10 (good)', 'gk-gravityview' );
 	}
 }

--- a/includes/admin/field-types/type_textarea.php
+++ b/includes/admin/field-types/type_textarea.php
@@ -35,7 +35,7 @@ class GravityView_FieldType_textarea extends GravityView_FieldType {
 		$show_mt = $this->show_merge_tags();
 
         if( $show_mt || $field_support_merge_tags ) {
-            $class .= ' merge-tag-support mt-position-right ';
+            $class .= ' gv-merge-tag-support mt-position-right ';
 
             if( empty( $this->field['show_all_fields'] ) ) {
             	$class .= ' mt-hide_all_fields ';

--- a/includes/class-admin-views.php
+++ b/includes/class-admin-views.php
@@ -872,18 +872,22 @@ class GravityView_Admin_Views {
 			$meta_fields = array();
 		}
 
-		// get default fields
-		$default_fields = $this->get_entry_default_fields( $form, $zone );
+		$gv_fields = GravityView_Fields::get_all( '', $zone );
 
-		//merge without loosing the keys
-		$fields = $fields + $meta_fields + $default_fields;
+		$featured_fields = wp_list_filter( $gv_fields, array( 'group' => 'featured' ) );
 
-		// Move Custom Content to top
-		if ( isset( $fields['custom'] ) ) {
-			$fields = array( 'custom' => $fields['custom'] ) + $fields;
+		// Convert from GravityView field into array.
+		/** @var GravityView_Field $featured_field */
+		foreach ( $featured_fields as &$featured_field ) {
+			$_as_array = $featured_field->as_array();
+			$featured_field = reset( $_as_array );
 		}
 
-		$gv_fields = GravityView_Fields::get_all( '', $zone );
+		// get default fields.
+		$default_fields = $this->get_entry_default_fields( $form, $zone );
+
+		//merge without losing the keys.
+		$fields = $featured_fields + $fields + $meta_fields + $default_fields;
 
 		foreach ( $fields as &$field ) {
 			foreach ( $gv_fields as $gv_field ) {

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -284,6 +284,14 @@ class GravityView_Welcome {
 				 *  - If 4.28, include to 4.26.
  				 */
 				?>
+				<h3>develop</h3>
+
+				<ul>
+					<li>Improved: View editor performance, especially with Views with a large number of fields</li>
+					<li>Improved: "Link to Edit Entry," "Link to Single Entry," and "Delete Entry" fields are now more easily accessible at the top of the field picker in the View editor</li>
+					<li>Fixed: PHP 8.1+ deprecation notice</li>
+				</ul>
+
 				<h3>2.19.3 on October 25, 2023</h3>
 
 				<ul>

--- a/includes/extensions/delete-entry/class-gravityview-field-delete-link.php
+++ b/includes/extensions/delete-entry/class-gravityview-field-delete-link.php
@@ -23,7 +23,7 @@ class GravityView_Field_Delete_Link extends GravityView_Field {
 	var $is_searchable = false;
 
 	/** @inheritDoc  */
-	var $group = 'gravityview';
+	var $group = 'featured';
 
 	/** @inheritDoc  */
 	var $icon = 'dashicons-trash';

--- a/includes/extensions/delete-entry/class-gravityview-field-delete-link.php
+++ b/includes/extensions/delete-entry/class-gravityview-field-delete-link.php
@@ -45,37 +45,6 @@ class GravityView_Field_Delete_Link extends GravityView_Field {
 	public function add_hooks() {
 		// For the Delete Entry Link, you don't want visible to all users.
 		add_filter( 'gravityview_field_visibility_caps', array( $this, 'modify_visibility_caps' ), 10, 5 );
-
-		// Add Delete Link as a default field, outside those set in the Gravity Forms form
-		add_filter( 'gravityview_entry_default_fields', array( $this, 'add_default_field' ), 10, 3 );
-	}
-
-	/**
-	 * Add as a default field, outside those set in the Gravity Form form
-	 *
-	 * @since 2.18.1
-	 *
-	 * @param array        $entry_default_fields Existing fields
-	 * @param string|array $form                 form_ID or form object
-	 * @param string       $zone                 Either 'single', 'directory', 'edit', 'header', 'footer'
-	 *
-	 * @return array
-	 */
-	public function add_default_field( $entry_default_fields, $form = array(), $zone = '' ) {
-
-		if ( 'directory' !== $zone ) {
-			return $entry_default_fields;
-		}
-
-		$entry_default_fields[ $this->name ] = array(
-			'label' => $this->label,
-			'type'  => $this->name,
-			'desc'  => $this->description,
-			'icon'  => $this->icon,
-			'group' => 'gravityview',
-		);
-
-		return $entry_default_fields;
 	}
 
 	/**

--- a/includes/extensions/edit-entry/class-edit-entry-admin.php
+++ b/includes/extensions/edit-entry/class-edit-entry-admin.php
@@ -28,14 +28,8 @@ class GravityView_Edit_Entry_Admin {
             return;
         }
 
-        // Add Edit Link as a default field, outside those set in the Gravity Form form
-        add_filter( 'gravityview_entry_default_fields', array( $this, 'add_default_field' ), 10, 3 );
-
         // For the Edit Entry Link, you don't want visible to all users.
         add_filter( 'gravityview_field_visibility_caps', array( $this, 'modify_visibility_caps' ), 10, 5 );
-
-        // Modify the field options based on the name of the field type
-        add_filter( 'gravityview_template_edit_link_options', array( $this, 'edit_link_field_options' ), 10, 5 );
 
         // add tooltips
         add_filter( 'gravityview/metaboxes/tooltips', array( $this, 'tooltips') );
@@ -74,28 +68,6 @@ class GravityView_Edit_Entry_Admin {
 	}
 
     /**
-     * Add Edit Link as a default field, outside those set in the Gravity Form form
-     * @param array $entry_default_fields Existing fields
-     * @param  string|array $form form_ID or form object
-     * @param  string $zone   Either 'single', 'directory', 'header', 'footer'
-     */
-    function add_default_field( $entry_default_fields, $form = array(), $zone = '' ) {
-
-        if( $zone !== 'edit' ) {
-
-            $entry_default_fields['edit_link'] = array(
-                'label' => __('Link to Edit Entry', 'gk-gravityview'),
-                'type' => 'edit_link',
-                'desc'	=> __('A link to edit the entry. Visible based on View settings.', 'gk-gravityview'),
-                'icon' => 'dashicons-welcome-write-blog',
-            );
-
-        }
-
-        return $entry_default_fields;
-    }
-
-    /**
      * Change wording for the Edit context to read Entry Creator
      *
      * @param  array 	   $visibility_caps        Array of capabilities to display in field dropdown.
@@ -108,56 +80,19 @@ class GravityView_Edit_Entry_Admin {
      */
     function modify_visibility_caps( $visibility_caps = array(), $template_id = '', $field_id = '', $context = '', $input_type = '' ) {
 
-        $caps = $visibility_caps;
-
-        // If we're configuring fields in the edit context, we want a limited selection
-        if( $context === 'edit' ) {
-
-            // Remove other built-in caps.
-            unset( $caps['publish_posts'], $caps['gravityforms_view_entries'], $caps['delete_others_posts'] );
-
-            $caps['read'] = _x('Entry Creator','User capability', 'gk-gravityview');
+        if( $context !== 'edit' ) {
+	        return $visibility_caps;
         }
 
+		// If we're configuring fields in the edit context, we want a limited selection.
+        $caps = $visibility_caps;
+
+        // Remove other built-in caps.
+        unset( $caps['publish_posts'], $caps['gravityforms_view_entries'], $caps['delete_others_posts'] );
+
+        $caps['read'] = _x('Entry Creator','User capability', 'gk-gravityview');
+
         return $caps;
-    }
-
-    /**
-     * Add "Edit Link Text" setting to the edit_link field settings
-     *
-     * @param array  $field_options
-     * @param string $template_id
-     * @param string $field_id
-     * @param string $context
-     * @param string $input_type
-     *
-     * @return array $field_options, with "Edit Link Text" field option
-     */
-    function edit_link_field_options( $field_options, $template_id, $field_id, $context, $input_type ) {
-
-        // Always a link, never a filter
-        unset( $field_options['show_as_link'], $field_options['search_filter'] );
-
-        // Edit Entry link should only appear to visitors capable of editing entries
-        unset( $field_options['only_loggedin'], $field_options['only_loggedin_cap'] );
-
-        $add_option['edit_link'] = array(
-            'type' => 'text',
-            'label' => __( 'Edit Link Text', 'gk-gravityview' ),
-            'desc' => NULL,
-            'value' => __('Edit Entry', 'gk-gravityview'),
-            'merge_tags' => true,
-        );
-
-	    $add_option['new_window'] = array(
-		    'type' => 'checkbox',
-		    'label' => __( 'Open link in a new tab or window?', 'gk-gravityview' ),
-		    'value' => false,
-		    'group' => 'display',
-		    'priority' => 1300,
-	    );
-
-        return array_merge( $add_option, $field_options );
     }
 
     /**

--- a/includes/fields/class-gravityview-field-custom.php
+++ b/includes/fields/class-gravityview-field-custom.php
@@ -38,33 +38,7 @@ class GravityView_Field_Custom extends GravityView_Field {
 
 		add_filter( 'gravityview/edit_entry/form_fields', array( $this, 'show_field_in_edit_entry' ), 10, 4 );
 
-		add_filter( 'gravityview_entry_default_fields', array( $this, 'add_default_field' ), 100, 3 );
-
 		parent::__construct();
-	}
-
-	/**
-	 * Add as a default field, outside those set in the Gravity Form form
-	 *
-	 * @since 2.10 Moved here from GravityView_Admin_Views::get_entry_default_fields
-	 *
-	 * @param array $entry_default_fields Existing fields
-	 * @param string|array $form form_ID or form object
-	 * @param string $zone Either 'single', 'directory', 'edit', 'header', 'footer'
-	 *
-	 * @return array
-	 */
-	public function add_default_field( $entry_default_fields, $form = array(), $zone = '' ) {
-
-		$entry_default_fields['custom']	= array(
-			'label'	=> $this->label,
-			'type'	=> $this->name,
-			'desc'	=> $this->description,
-			'icon'  => $this->icon,
-			'group' => $this->group,
-		);
-
-		return $entry_default_fields;
 	}
 
 	public function field_options( $field_options, $template_id, $field_id, $context, $input_type, $form_id ) {

--- a/includes/fields/class-gravityview-field-custom.php
+++ b/includes/fields/class-gravityview-field-custom.php
@@ -27,7 +27,7 @@ class GravityView_Field_Custom extends GravityView_Field {
 	 */
 	var $is_searchable = false;
 
-	var $group = 'gravityview';
+	var $group = 'featured';
 
 	var $icon = 'dashicons-editor-code';
 

--- a/includes/fields/class-gravityview-field-edit-link.php
+++ b/includes/fields/class-gravityview-field-edit-link.php
@@ -10,25 +10,25 @@
  */
 class GravityView_Field_Edit_Link extends GravityView_Field {
 
-	var $name = 'edit_link';
+	public $name = 'edit_link';
 
-	var $contexts = array( 'single', 'multiple' );
-
-	/**
-	 * @var bool
-	 * @since 1.15.3
-	 */
-	var $is_sortable = false;
+	public $contexts = [ 'single', 'multiple' ];
 
 	/**
 	 * @var bool
 	 * @since 1.15.3
 	 */
-	var $is_searchable = false;
+	public $is_sortable = false;
+
+	/**
+	 * @var bool
+	 * @since 1.15.3
+	 */
+	public $is_searchable = false;
 
 	public $group = 'featured';
 
-	var $icon = 'dashicons-welcome-write-blog';
+	public $icon = 'dashicons-welcome-write-blog';
 
 	public function __construct() {
 		$this->label = esc_html__( 'Link to Edit Entry', 'gk-gravityview' );

--- a/includes/fields/class-gravityview-field-edit-link.php
+++ b/includes/fields/class-gravityview-field-edit-link.php
@@ -49,21 +49,15 @@ class GravityView_Field_Edit_Link extends GravityView_Field {
 		// Edit Entry link should only appear to visitors capable of editing entries
 		unset( $field_options['only_loggedin'], $field_options['only_loggedin_cap'] );
 
-		$add_option['edit_link'] = array(
+		$add_option['edit_link'] = [
 			'type' => 'text',
 			'label' => __( 'Edit Link Text', 'gk-gravityview' ),
 			'desc' => NULL,
 			'value' => __('Edit Entry', 'gk-gravityview'),
 			'merge_tags' => true,
-		);
+		];
 
-		$add_option['new_window'] = array(
-			'type' => 'checkbox',
-			'label' => __( 'Open link in a new tab or window?', 'gk-gravityview' ),
-			'value' => false,
-			'group' => 'display',
-			'priority' => 1300,
-		);
+		$this->add_field_support( 'new_window', $field_options );
 
 		return array_merge( $add_option, $field_options );
 	}

--- a/includes/fields/class-gravityview-field-edit-link.php
+++ b/includes/fields/class-gravityview-field-edit-link.php
@@ -26,7 +26,7 @@ class GravityView_Field_Edit_Link extends GravityView_Field {
 	 */
 	var $is_searchable = false;
 
-	var $group = 'gravityview';
+	public $group = 'featured';
 
 	var $icon = 'dashicons-welcome-write-blog';
 

--- a/includes/fields/class-gravityview-field-edit-link.php
+++ b/includes/fields/class-gravityview-field-edit-link.php
@@ -33,34 +33,8 @@ class GravityView_Field_Edit_Link extends GravityView_Field {
 	public function __construct() {
 		$this->label = esc_html__( 'Link to Edit Entry', 'gk-gravityview' );
 		$this->description = esc_html__('A link to edit the entry. Visible based on View settings.', 'gk-gravityview');
+
 		parent::__construct();
-	}
-
-	/**
-	 * Add as a default field, outside those set in the Gravity Form form
-	 *
-	 * @since 2.10 Moved here from GravityView_Admin_Views::get_entry_default_fields
-	 *
-	 * @param array $entry_default_fields Existing fields
-	 * @param string|array $form form_ID or form object
-	 * @param string $zone Either 'single', 'directory', 'edit', 'header', 'footer'
-	 *
-	 * @return array
-	 */
-	public function add_default_field( $entry_default_fields, $form = array(), $zone = '' ) {
-
-		if ( 'directory' !== $zone ) {
-			return $entry_default_fields;
-		}
-
-		$entry_default_fields[ $this->name ] = array(
-			'label' => $this->label,
-			'type'  => $this->name,
-			'desc'  => $this->description,
-			'icon'  => $this->icon,
-		);
-
-		return $entry_default_fields;
 	}
 
 	public function field_options( $field_options, $template_id, $field_id, $context, $input_type, $form_id ) {

--- a/includes/fields/class-gravityview-field-edit-link.php
+++ b/includes/fields/class-gravityview-field-edit-link.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Add custom options for entry_link fields
+ * Add custom options for edit_link fields
  */
 class GravityView_Field_Edit_Link extends GravityView_Field {
 
@@ -16,13 +16,11 @@ class GravityView_Field_Edit_Link extends GravityView_Field {
 
 	/**
 	 * @var bool
-	 * @since 1.15.3
 	 */
 	public $is_sortable = false;
 
 	/**
 	 * @var bool
-	 * @since 1.15.3
 	 */
 	public $is_searchable = false;
 

--- a/includes/fields/class-gravityview-field-edit-link.php
+++ b/includes/fields/class-gravityview-field-edit-link.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @file class-gravityview-field-edit-link.php
+ * @package GravityView
+ * @subpackage includes\fields
+ */
+
+/**
+ * Add custom options for entry_link fields
+ */
+class GravityView_Field_Edit_Link extends GravityView_Field {
+
+	var $name = 'edit_link';
+
+	var $contexts = array( 'single', 'multiple' );
+
+	/**
+	 * @var bool
+	 * @since 1.15.3
+	 */
+	var $is_sortable = false;
+
+	/**
+	 * @var bool
+	 * @since 1.15.3
+	 */
+	var $is_searchable = false;
+
+	var $group = 'gravityview';
+
+	var $icon = 'dashicons-welcome-write-blog';
+
+	public function __construct() {
+		$this->label = esc_html__( 'Link to Edit Entry', 'gk-gravityview' );
+		$this->description = esc_html__('A link to edit the entry. Visible based on View settings.', 'gk-gravityview');
+		parent::__construct();
+	}
+
+	/**
+	 * Add as a default field, outside those set in the Gravity Form form
+	 *
+	 * @since 2.10 Moved here from GravityView_Admin_Views::get_entry_default_fields
+	 *
+	 * @param array $entry_default_fields Existing fields
+	 * @param string|array $form form_ID or form object
+	 * @param string $zone Either 'single', 'directory', 'edit', 'header', 'footer'
+	 *
+	 * @return array
+	 */
+	public function add_default_field( $entry_default_fields, $form = array(), $zone = '' ) {
+
+		if ( 'directory' !== $zone ) {
+			return $entry_default_fields;
+		}
+
+		$entry_default_fields[ $this->name ] = array(
+			'label' => $this->label,
+			'type'  => $this->name,
+			'desc'  => $this->description,
+			'icon'  => $this->icon,
+		);
+
+		return $entry_default_fields;
+	}
+
+	public function field_options( $field_options, $template_id, $field_id, $context, $input_type, $form_id ) {
+
+		if( 'edit' === $context ) {
+			return $field_options;
+		}
+
+		// Always a link, never a filter
+		unset( $field_options['show_as_link'], $field_options['search_filter'] );
+
+		// Edit Entry link should only appear to visitors capable of editing entries
+		unset( $field_options['only_loggedin'], $field_options['only_loggedin_cap'] );
+
+		$add_option['edit_link'] = array(
+			'type' => 'text',
+			'label' => __( 'Edit Link Text', 'gk-gravityview' ),
+			'desc' => NULL,
+			'value' => __('Edit Entry', 'gk-gravityview'),
+			'merge_tags' => true,
+		);
+
+		$add_option['new_window'] = array(
+			'type' => 'checkbox',
+			'label' => __( 'Open link in a new tab or window?', 'gk-gravityview' ),
+			'value' => false,
+			'group' => 'display',
+			'priority' => 1300,
+		);
+
+		return array_merge( $add_option, $field_options );
+	}
+
+}
+
+new GravityView_Field_Edit_Link;

--- a/includes/fields/class-gravityview-field-entry-link.php
+++ b/includes/fields/class-gravityview-field-entry-link.php
@@ -26,7 +26,7 @@ class GravityView_Field_Entry_Link extends GravityView_Field {
 	 */
 	var $is_searchable = false;
 
-	var $group = 'gravityview';
+	public $group = 'featured';
 
 	var $icon = 'dashicons-media-default';
 
@@ -58,6 +58,7 @@ class GravityView_Field_Entry_Link extends GravityView_Field {
 			'type'  => $this->name,
 			'desc'  => $this->description,
 			'icon'  => $this->icon,
+			'group'  => $this->group,
 		);
 
 		return $entry_default_fields;

--- a/includes/fields/class-gravityview-field-entry-link.php
+++ b/includes/fields/class-gravityview-field-entry-link.php
@@ -10,25 +10,25 @@
  */
 class GravityView_Field_Entry_Link extends GravityView_Field {
 
-	var $name = 'entry_link';
+	public $name = 'entry_link';
 
-	var $contexts = array( 'multiple' );
-
-	/**
-	 * @var bool
-	 * @since 1.15.3
-	 */
-	var $is_sortable = false;
+	public $contexts = array( 'multiple' );
 
 	/**
 	 * @var bool
 	 * @since 1.15.3
 	 */
-	var $is_searchable = false;
+	public $is_sortable = false;
+
+	/**
+	 * @var bool
+	 * @since 1.15.3
+	 */
+	public $is_searchable = false;
 
 	public $group = 'featured';
 
-	var $icon = 'dashicons-media-default';
+	public $icon = 'dashicons-media-default';
 
 	public function __construct() {
 		$this->label = esc_html__( 'Link to Single Entry', 'gk-gravityview' );

--- a/includes/fields/class-gravityview-field.php
+++ b/includes/fields/class-gravityview-field.php
@@ -83,13 +83,13 @@ abstract class GravityView_Field {
 	 * @see https://www.gravityhelp.com/documentation/article/gform_entry_meta/
 	 * @since 1.19
 	 */
-	var $entry_meta_update_callback = null;
+	public $entry_meta_update_callback = null;
 
 	/**
 	 * @var bool Whether to show meta when set to true automatically adds the column to the entry list, without having to edit and add the column for display
 	 * @since 1.19
 	 */
-	var $entry_meta_is_default_column = false;
+	public $entry_meta_is_default_column = false;
 
 	/**
 	 * @internal Not yet implemented

--- a/includes/fields/class-gravityview-field.php
+++ b/includes/fields/class-gravityview-field.php
@@ -36,7 +36,9 @@ abstract class GravityView_Field {
 	public $default_search_label;
 
 	/**
-	 * `standard`, `advanced`, `post`, `pricing`, `meta`, `gravityview`, or `add-ons`
+	 * `standard`, `advanced`, `post`, `pricing`, `meta`, `gravityview`, or `add-ons`, or `featured`.
+	 *
+	 * Featured are moved to the top of the field picker.
 	 *
 	 * @since 1.15.2
 	 * @type string The group belongs to this field in the field picker

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 = develop =
 
 * Improved: View editor performance, especially with Views with a large number of fields
+* Improved: "Link to Edit Entry," "Link to Single Entry," and "Delete Entry" fields are now more easily accessible at the top of the field picker in the View editor
 * Fixed: PHP 8.1+ deprecation notice
 
 = 2.19.3 on October 25, 2023 =

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
+* Improved: View editor performance, especially with Views with a large number of fields
 * Fixed: PHP 8.1+ deprecation notice
 
 = 2.19.3 on October 25, 2023 =


### PR DESCRIPTION
- Resolves #1814
- Resolves #1946 
- Fixes #1947
------

## Testing

This changes how we process toggles that show and hide values based on checkboxes.

We need to make sure that if a checkbox is checked that is supposed to show another field (like "Show Label"), the fields remain checked and the dependency fields remain visible.

![](https://i.gravitykit.com/i/YLIETZ+)

Same for settings fields, like "Allow User Edit"—when checked, should show "Unapprove Entries After Edit".

![](https://i.gravitykit.com/i/NP1Nmn+)

Same with Maps:
![](https://i.gravitykit.com/i/BI4zMP+)