### PR TITLE
Support advanced post creation add on

### DIFF
--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -329,7 +329,7 @@
 
 				var show_warning = ! dismissed_warning && value.configured === 0;
 
-				$( '#' + index + '-fields' ).find( '.notice-warning' ).toggle( show_warning );
+				$( '#' + index + '-fields' ).find( '.notice-no-link' ).toggle( show_warning );
 				$( 'li[aria-controls="' + index + '-view"]' )
 					.toggleClass( 'tab-not-configured', show_warning )
 					.find( '.tab-icon' )

--- a/future/includes/class-gv-form.php
+++ b/future/includes/class-gv-form.php
@@ -24,7 +24,7 @@ abstract class Form extends Source {
 	/**
 	 * @var array The backing form.
 	 */
-	protected $form;
+	private $form;
 
 	/**
 	 * Construct a \GV\Form instance by ID.

--- a/future/includes/class-gv-form.php
+++ b/future/includes/class-gv-form.php
@@ -24,7 +24,7 @@ abstract class Form extends Source {
 	/**
 	 * @var array The backing form.
 	 */
-	private $form;
+	protected $form;
 
 	/**
 	 * Construct a \GV\Form instance by ID.

--- a/includes/admin/metaboxes/views/view-configuration.php
+++ b/includes/admin/metaboxes/views/view-configuration.php
@@ -62,7 +62,7 @@
 
 		<div id="single-fields" class="gv-section">
 
-			<div class="notice notice-warning inline is-dismissible">
+			<div class="notice notice-warning notice-no-link inline is-dismissible">
 				<h3><?php printf( esc_html__( 'Note: %s', 'gk-gravityview' ), sprintf( esc_html__( 'No fields link to the %s layout.', 'gk-gravityview' ), esc_html__( 'Single Entry', 'gk-gravityview' ) ) ); ?></h3>
 				<p><a data-beacon-article-modal="54c67bbae4b0512429885516" href="https://docs.gravitykit.com/article/70-linking-to-a-single-entry"><?php printf( esc_html__( 'Learn how to link to %s', 'gk-gravityview' ), esc_html__( 'Single Entry', 'gk-gravityview' ) ); ?></a></p>
 			</div>
@@ -87,7 +87,7 @@
 
 		<div id="edit-fields" class="gv-section">
 
-			<div class="notice notice-warning inline is-dismissible">
+			<div class="notice notice-warning notice-no-link inline is-dismissible">
 				<h3><?php printf( esc_html__( 'Note: %s', 'gk-gravityview' ), sprintf( esc_html__( 'No fields link to the %s layout.', 'gk-gravityview' ), esc_html__( 'Edit Entry', 'gk-gravityview' ) ) ); ?></h3>
 				<p><a data-beacon-article-modal="54c67bb9e4b0512429885513" href="https://docs.gravitykit.com/article/67-configuring-the-edit-entry-screen"><?php printf( esc_html__( 'Learn how to link to %s', 'gk-gravityview' ), esc_html__( 'Edit Entry', 'gk-gravityview' ) ); ?></a></p>
 			</div>

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
@@ -95,9 +95,15 @@ HTML;
 
 		$notification = sprintf(
 			$notification_html,
-			esc_html__( 'Caution: Advanced Post Creation is active for this form', 'gk-gravityview' ),
+			esc_html__( 'Caution: [link]Advanced Post Creation[/link] is active for this form', 'gk-gravityview' ),
 			__( 'Editing one of these entries might update a connected post as well. ', 'gk-gravityview' )
 		);
+
+		$apc_feed_link = admin_url( sprintf( 'admin.php?page=gf_edit_forms&amp;view=settings&amp;subview=%s&amp;id=%d', $apc->get_slug(), $form->ID ) );
+		$notification  = strtr( $notification, [
+			'[link]'  => '<a style="font-size: inherit;" href="' . $apc_feed_link . '" target="_blank">',
+			'[/link]' => '</a>',
+		] );
 
 		if ( $echo ) {
 			echo $notification;

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Add Gravity Forms Advanced Post Creation compatibility.
+ * @since $ver$
+ * @link  https://www.gravityforms.com/add-ons/advanced-post-creation/
+ */
+final class GravityView_Plugin_Hooks_Gravity_Forms_Advanced_Post_Creation extends GravityView_Plugin_and_Theme_Hooks {
+	/**
+	 * @inheritDoc
+	 * @since $ver$
+	 */
+	protected $class_name = 'GF_Advanced_Post_Creation';
+
+	/**
+	 * Updates the connected post.
+	 * @since $ver$
+	 *
+	 * @param array                         $form     Gravity Forms form array.
+	 * @param string                        $entry_id Numeric ID of the entry that was updated.
+	 * @param GravityView_Edit_Entry_Render $render   The entry renderer.
+	 */
+	public function update_post_on_entry_edit( array $form, string $entry_id, GravityView_Edit_Entry_Render $render ): void {
+		if ( ! $form || ! $entry_id ) {
+			return;
+		}
+
+		// Todo: disable if setting is not activated in Foudation.
+
+		$apc = GF_Advanced_Post_Creation::get_instance();
+
+		$created_posts = gform_get_meta( $entry_id, $apc->get_slug() . '_post_id' );
+		if ( ! $created_posts ) {
+			return;
+		}
+
+		$feeds = $apc->get_active_feeds( rgar( $form, 'id' ) );
+		if ( ! $feeds ) {
+			return;
+		}
+
+		// Map feeds on their id for easy access.
+		$feeds = array_column( $feeds, null, 'id' );
+
+		foreach ( $created_posts as $created_post ) {
+			$feed_id = rgar( $created_post, 'feed_id' );
+			$feed    = rgar( $feeds, $feed_id );
+			if ( ! $feed ) {
+				continue;
+			}
+
+			$apc->update_post( $created_post['post_id'], $feed, $render->entry, $form );
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since $ver$
+	 */
+	protected function add_hooks(): void {
+		parent::add_hooks();
+
+		add_action( 'gravityview/edit_entry/after_update', [ $this, 'update_post_on_entry_edit' ], 10, 3 );
+	}
+}
+
+new GravityView_Plugin_Hooks_Gravity_Forms_Advanced_Post_Creation;

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
@@ -101,8 +101,8 @@ HTML;
 
 		$apc_feed_link = admin_url( sprintf( 'admin.php?page=gf_edit_forms&amp;view=settings&amp;subview=%s&amp;id=%d', $apc->get_slug(), $form->ID ) );
 		$notification  = strtr( $notification, [
-			'[link]'  => '<a style="font-size: inherit;" href="' . $apc_feed_link . '" target="_blank">',
 			'[/link]' => '</a>',
+			'[link]'  => '<a style="font-size: inherit;" href="' . esc_url( $apc_feed_link ) . '" target="_blank">',
 		] );
 
 		if ( $echo ) {

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
@@ -39,16 +39,16 @@ final class GravityView_Plugin_Hooks_Gravity_Forms_Advanced_Post_Creation extend
 			return;
 		}
 
-		// Todo: disable if setting is not activated in Foundation.
-
 		$apc = GF_Advanced_Post_Creation::get_instance();
 
 		$created_posts = gform_get_meta( $entry_id, $apc->get_slug() . '_post_id' );
+
 		if ( ! $created_posts ) {
 			return;
 		}
 
 		$feeds = $apc->get_active_feeds( rgar( $form, 'id' ) );
+
 		if ( ! $feeds ) {
 			return;
 		}

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * Add Advanced Post Creation customizations.
+ *
+ * @file      class-gravityview-plugin-hooks-code-snippets.php
+ * @package   GravityView
+ * @license   GPL2+
+ * @author    GravityKit <hello@gravitykit.com>
+ * @link      http://www.gravitykit.com
+ * @copyright Copyright 2024, Katz Web Services, Inc.
+ *
+ * @since $ver$
+ */
 
 use GV\View;
 
@@ -27,7 +39,7 @@ final class GravityView_Plugin_Hooks_Gravity_Forms_Advanced_Post_Creation extend
 			return;
 		}
 
-		// Todo: disable if setting is not activated in Foudation.
+		// Todo: disable if setting is not activated in Foundation.
 
 		$apc = GF_Advanced_Post_Creation::get_instance();
 

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
@@ -109,7 +109,7 @@ HTML;
 			$notification_html,
 			// translators: Do not translate [link] and [/link]; they are replaced with an anchor tag.
 			esc_html__( 'Caution: [link]Advanced Post Creation[/link] is active for this form.', 'gk-gravityview' ),
-			__( 'Editing entries in GravityView may also update a connected post.', 'gk-gravityview' )
+			esc_html__( 'Editing entries in GravityView may also update a connected post.', 'gk-gravityview' )
 		);
 
 		$apc_feed_link = admin_url( sprintf( 'admin.php?page=gf_edit_forms&amp;view=settings&amp;subview=%s&amp;id=%d', $apc->get_slug(), $form->ID ) );

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
@@ -101,8 +101,8 @@ HTML;
 
 		$apc_feed_link = admin_url( sprintf( 'admin.php?page=gf_edit_forms&amp;view=settings&amp;subview=%s&amp;id=%d', $apc->get_slug(), $form->ID ) );
 		$notification  = strtr( $notification, [
-			'[/link]' => '</a>',
 			'[link]'  => '<a style="font-size: inherit;" href="' . esc_url( $apc_feed_link ) . '" target="_blank">',
+			'[/link]' =>  '<span class="screen-reader-text"> ' . esc_html__( '(This link opens in a new window.)', 'gk-gravityview' ) . '</span></a>',
 		] );
 
 		if ( $echo ) {

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
@@ -95,11 +95,13 @@ HTML;
 
 		$notification = sprintf(
 			$notification_html,
-			esc_html__( 'Caution: [link]Advanced Post Creation[/link] is active for this form', 'gk-gravityview' ),
-			__( 'Editing one of these entries might update a connected post as well. ', 'gk-gravityview' )
+			// translators: Do not translate [link] and [/link]; they are replaced with an anchor tag.
+			esc_html__( 'Caution: [link]Advanced Post Creation[/link] is active for this form.', 'gk-gravityview' ),
+			__( 'Editing entries in GravityView may also update a connected post.', 'gk-gravityview' )
 		);
 
 		$apc_feed_link = admin_url( sprintf( 'admin.php?page=gf_edit_forms&amp;view=settings&amp;subview=%s&amp;id=%d', $apc->get_slug(), $form->ID ) );
+
 		$notification  = strtr( $notification, [
 			'[link]'  => '<a style="font-size: inherit;" href="' . esc_url( $apc_feed_link ) . '" target="_blank">',
 			'[/link]' =>  '<span class="screen-reader-text"> ' . esc_html__( '(This link opens in a new window.)', 'gk-gravityview' ) . '</span></a>',

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+* Added: Support for the [Advanced Post Creation Add-On](https://www.gravityforms.com/add-ons/advanced-post-creation/) when editing entries in GravityView's Edit Entry mode
+
+
 = 2.19.6 on February 7, 2024 =
 
 This update introduces the ability to send notifications using Gravity Forms when an entry is deleted, improves sorting and survey field ratings, and updates key components for better performance and compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 This release makes it easier to customize search results per-View instead of globally using code.
 
 * Added: Ability to send notifications using Gravity Forms when an entry is deleted by selecting the "GravityView - Entry is deleted" event from the event dropdown in Gravity Forms notifications settings
+* Added: Support for editing with the Advanced Post Creation add-on
 * Fixed: Sorting the View by entry ID in ascending and descending order would yield the same result
 * Fixed: Survey fields without a rating would show a 1-star rating
 * Fixed: Custom Post Field acting as File Uploads can now be edited on the Edit Entry page


### PR DESCRIPTION
This PR addresses #1268 . 

It updates the connected Post if the entry is edited through GravityKit. **So not for gravity forms editing itself!**.

It also shows a notice if you provide an edit page and the APC add-on is active. 

<img width="1002" alt="image" src="https://github.com/GravityKit/GravityView/assets/529515/ea56bfd6-8389-492f-a1e1-d6ad2b4d51d5">
