### PR TITLE
Implement global and per-View caching of entries

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -237,12 +237,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:GravityKit/Foundation.git",
-                "reference": "9ab620244705ec166b6a1848a737addb040edb51"
+                "reference": "5a2457f27a037fc34aae8d0786cada8be80cbc87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GravityKit/Foundation/zipball/9ab620244705ec166b6a1848a737addb040edb51",
-                "reference": "9ab620244705ec166b6a1848a737addb040edb51",
+                "url": "https://api.github.com/repos/GravityKit/Foundation/zipball/5a2457f27a037fc34aae8d0786cada8be80cbc87",
+                "reference": "5a2457f27a037fc34aae8d0786cada8be80cbc87",
                 "shasum": ""
             },
             "require": {
@@ -322,10 +322,10 @@
                 }
             ],
             "support": {
-                "source": "https://github.com/GravityKit/Foundation/tree/v1.2.8",
+                "source": "https://github.com/GravityKit/Foundation/tree/main",
                 "issues": "https://github.com/GravityKit/Foundation/issues"
             },
-            "time": "2024-02-07T15:22:05+00:00"
+            "time": "2024-02-20T22:40:30+00:00"
         },
         {
             "name": "illuminate/container",

--- a/future/includes/class-gv-settings-plugin.php
+++ b/future/includes/class-gv-settings-plugin.php
@@ -231,50 +231,111 @@ class Plugin_Settings {
 
 		$default_settings = $this->defaults();
 
-		$cache_settings = array(
-			array(
-				'id'          => 'caching',
-				'type'        => 'checkbox',
-				'title'       => esc_html__( 'Enable Caching', 'gk-gravityview' ),
-				'description' => esc_html__( 'Enabling caching improves performance by reducing the number of queries during page loads. When enabled, you can also specify cache duration for entries and DataTables output.', 'gk-gravityview' ),
-				'value'       => $this->get( 'caching', $default_settings['caching'] ),
-			),
-			array(
-				'id'          => 'caching_entries',
-				'type'        => 'number',
-				'requires'    => array(
-					'id'       => 'caching',
-					'operator' => '==',
-					'value'    => 1,
-				),
-				'validation'  => array(
-					array(
-						'rule'    => 'min:1',
-						'message' => esc_html__( 'The cache duration must be at least 1 second.', 'gk-gravityview' ),
+		$cache_filters_in_use = [];
+
+		if ( has_filter( 'gravityview_use_cache' ) ) {
+			$cache_filters_in_use[] = 'gravityview_use_cache';
+		}
+
+		if ( has_filter( 'gravityview_cache_time_entries' ) ) {
+			$cache_filters_in_use[] = 'gravityview_cache_time_entries';
+		}
+
+		if ( has_filter( 'gravityview_cache_time_datatables_output' ) ) {
+			$cache_filters_in_use[] = 'gravityview_cache_time_datatables_output';
+		}
+
+		$cache_settings = [];
+
+		if ( ! empty( $cache_filters_in_use ) ) {
+			$notice = 1 === count( $cache_filters_in_use )
+				? esc_html__( 'Caching settings are being manually overridden by the [filter] filter.', 'gk-gravityview' )
+				: esc_html_x( 'Caching settings are being manually overridden by the following filters: [filters].', 'gk-gravityview' );
+
+			$notice = strtr(
+				$notice,
+				[
+					'[filter]' => '<code>' . implode( '</code>, <code>', $cache_filters_in_use ) . '</code>',
+					'[filters]' => '<code>' . implode( '</code>, <code>', $cache_filters_in_use ) . '</code>',
+				]
+			);
+
+			$notice = <<<HTML
+<div class="bg-yellow-50 p-4 rounded-md">
+	<div class="flex">
+		<div class="flex-shrink-0">
+			<svg class="h-5 w-5 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+				<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+			</svg>
+		</div>
+		<div class="ml-3">
+			<p class="text-sm">
+				{$notice}
+			</p>
+		</div>
+	</div>
+</div>
+HTML;
+
+			$cache_settings[] = [
+				'id'              => 'caching_filters_notice',
+				'html'            => $notice,
+				'markdown'        => false,
+				'excludeFromSave' => true,
+			];
+		}
+
+		$cache_settings = array_merge( $cache_settings, [
+				array(
+					'id'          => 'caching',
+					'type'        => 'checkbox',
+					'title'       => esc_html__( 'Enable Caching', 'gk-gravityview' ),
+					'description' => strtr(
+						esc_html_x( '[url]Enabling caching[/url] improves performance by reducing the number of queries during page loads. When enabled, you can also specify cache duration for entries and DataTables output.', 'Placeholders inside [] are not to be translated.', 'gk-gravityview' ),
+						[
+							'[url]'  => '<a class="underline" href="https://docs.gravitykit.com/article/58-about-gravityview-caching" rel="noopener noreferrer">',
+							'[/url]' => '</a>',
+						]
 					),
+					'value'       => $this->get( 'caching', $default_settings['caching'] ),
 				),
-				'title'       => esc_html__( 'Entry Cache Duration', 'gk-gravityview' ),
-				'description' => esc_html__( 'Specify the duration in seconds that entry data should remain cached before being refreshed. A shorter duration ensures more up-to-date data, while a longer duration improves performance.', 'gk-gravityview' ),
-				'value'       => $this->get( 'caching_entries', $default_settings['caching_entries'] ),
-			),
-			array(
-				'id'          => 'caching_datatables_output',
-				'type'        => 'number',
-				'requires'    => array(
-					'id'       => 'caching',
-					'operator' => '==',
-					'value'    => 1,
-				),
-				'validation'  => array(
-					array(
-						'rule'    => 'min:1',
-						'message' => esc_html__( 'The cache duration must be at least 1 second.', 'gk-gravityview' ),
+				array(
+					'id'          => 'caching_entries',
+					'type'        => 'number',
+					'requires'    => array(
+						'id'       => 'caching',
+						'operator' => '==',
+						'value'    => 1,
 					),
+					'validation'  => array(
+						array(
+							'rule'    => 'min:1',
+							'message' => esc_html__( 'The cache duration must be at least 1 second.', 'gk-gravityview' ),
+						),
+					),
+					'title'       => esc_html__( 'Entry Cache Duration', 'gk-gravityview' ),
+					'description' => esc_html__( 'Specify the duration in seconds that entry data should remain cached before being refreshed. A shorter duration ensures more up-to-date data, while a longer duration improves performance.', 'gk-gravityview' ),
+					'value'       => $this->get( 'caching_entries', $default_settings['caching_entries'] ),
 				),
-				'title'       => esc_html__( 'DataTables Cache Duration', 'gk-gravityview' ),
-				'description' => esc_html__( 'Define the cache lifetime in seconds for DataTables output. Adjusting this setting can balance between performance gains and data currency for your DataTables Views.', 'gk-gravityview' ),
-				'value'       => $this->get( 'caching_datatables_output', $default_settings['caching_datatables_output'] ),
-			),
+				array(
+					'id'          => 'caching_datatables_output',
+					'type'        => 'number',
+					'requires'    => array(
+						'id'       => 'caching',
+						'operator' => '==',
+						'value'    => 1,
+					),
+					'validation'  => array(
+						array(
+							'rule'    => 'min:1',
+							'message' => esc_html__( 'The cache duration must be at least 1 second.', 'gk-gravityview' ),
+						),
+					),
+					'title'       => esc_html__( 'DataTables Cache Duration', 'gk-gravityview' ),
+					'description' => esc_html__( 'Define the cache lifetime in seconds for DataTables output. Adjusting this setting can balance between performance gains and data currency for your DataTables Views.', 'gk-gravityview' ),
+					'value'       => $this->get( 'caching_datatables_output', $default_settings['caching_datatables_output'] ),
+				)
+			]
 		);
 
 		$settings = array(

--- a/future/includes/class-gv-settings-plugin.php
+++ b/future/includes/class-gv-settings-plugin.php
@@ -191,8 +191,11 @@ class Plugin_Settings {
 	 */
 	public function defaults() {
 		$defaults = array(
-			'rest_api'                => 0,
-			'public_entry_moderation' => 0,
+			'rest_api'                  => 0,
+			'public_entry_moderation'   => 0,
+			'caching'                   => 1,
+			'caching_entries'           => DAY_IN_SECONDS,
+			'caching_datatables_output' => DAY_IN_SECONDS,
 		);
 
 		/**
@@ -228,6 +231,52 @@ class Plugin_Settings {
 
 		$default_settings = $this->defaults();
 
+		$cache_settings = array(
+			array(
+				'id'          => 'caching',
+				'type'        => 'checkbox',
+				'title'       => esc_html__( 'Enable Caching', 'gk-gravityview' ),
+				'description' => esc_html__( 'Enabling caching improves performance by reducing the number of queries during page loads. When enabled, you can also specify cache duration for entries and DataTables output.', 'gk-gravityview' ),
+				'value'       => $this->get( 'caching', $default_settings['caching'] ),
+			),
+			array(
+				'id'          => 'caching_entries',
+				'type'        => 'number',
+				'requires'    => array(
+					'id'       => 'caching',
+					'operator' => '==',
+					'value'    => 1,
+				),
+				'validation'  => array(
+					array(
+						'rule'    => 'min:1',
+						'message' => esc_html__( 'The cache duration must be at least 1 second.', 'gk-gravityview' ),
+					),
+				),
+				'title'       => esc_html__( 'Entry Cache Duration', 'gk-gravityview' ),
+				'description' => esc_html__( 'Specify the duration in seconds that entry data should remain cached before being refreshed. A shorter duration ensures more up-to-date data, while a longer duration improves performance.', 'gk-gravityview' ),
+				'value'       => $this->get( 'caching_entries', $default_settings['caching_entries'] ),
+			),
+			array(
+				'id'          => 'caching_datatables_output',
+				'type'        => 'number',
+				'requires'    => array(
+					'id'       => 'caching',
+					'operator' => '==',
+					'value'    => 1,
+				),
+				'validation'  => array(
+					array(
+						'rule'    => 'min:1',
+						'message' => esc_html__( 'The cache duration must be at least 1 second.', 'gk-gravityview' ),
+					),
+				),
+				'title'       => esc_html__( 'DataTables Cache Duration', 'gk-gravityview' ),
+				'description' => esc_html__( 'Define the cache lifetime in seconds for DataTables output. Adjusting this setting can balance between performance gains and data currency for your DataTables Views.', 'gk-gravityview' ),
+				'value'       => $this->get( 'caching_datatables_output', $default_settings['caching_datatables_output'] ),
+			),
+		);
+
 		$settings = array(
 			'id'       => self::SETTINGS_PLUGIN_ID,
 			'title'    => 'GravityView',
@@ -245,6 +294,10 @@ class Plugin_Settings {
 							'value'       => $this->get( 'rest_api', $default_settings['rest_api'] ),
 						),
 					),
+				),
+				array(
+					'title'    => esc_html__( 'Caching', 'gk-gravityview' ),
+					'settings' => $cache_settings,
 				),
 				array(
 					'title'    => esc_html__( 'Permissions', 'gk-gravityview' ),

--- a/future/includes/class-gv-settings-plugin.php
+++ b/future/includes/class-gv-settings-plugin.php
@@ -195,7 +195,6 @@ class Plugin_Settings {
 			'public_entry_moderation'   => 0,
 			'caching'                   => 1,
 			'caching_entries'           => DAY_IN_SECONDS,
-			'caching_datatables_output' => DAY_IN_SECONDS,
 		);
 
 		/**
@@ -239,10 +238,6 @@ class Plugin_Settings {
 
 		if ( has_filter( 'gravityview_cache_time_entries' ) ) {
 			$cache_filters_in_use[] = 'gravityview_cache_time_entries';
-		}
-
-		if ( has_filter( 'gravityview_cache_time_datatables_output' ) ) {
-			$cache_filters_in_use[] = 'gravityview_cache_time_datatables_output';
 		}
 
 		$cache_settings = [];
@@ -291,7 +286,7 @@ HTML;
 					'type'        => 'checkbox',
 					'title'       => esc_html__( 'Enable Caching', 'gk-gravityview' ),
 					'description' => strtr(
-						esc_html_x( '[url]Enabling caching[/url] improves performance by reducing the number of queries during page loads. When enabled, you can also specify cache duration for entries and DataTables output.', 'Placeholders inside [] are not to be translated.', 'gk-gravityview' ),
+						esc_html_x( '[url]Enabling caching[/url] improves performance by reducing the number of queries during page loads. When enabled, you can also specify cache duration for entries.', 'Placeholders inside [] are not to be translated.', 'gk-gravityview' ),
 						[
 							'[url]'  => '<a class="underline" href="https://docs.gravitykit.com/article/58-about-gravityview-caching" rel="noopener noreferrer">',
 							'[/url]' => '</a>',
@@ -317,24 +312,6 @@ HTML;
 					'description' => esc_html__( 'Specify the duration in seconds that entry data should remain cached before being refreshed. A shorter duration ensures more up-to-date data, while a longer duration improves performance.', 'gk-gravityview' ),
 					'value'       => $this->get( 'caching_entries', $default_settings['caching_entries'] ),
 				),
-				array(
-					'id'          => 'caching_datatables_output',
-					'type'        => 'number',
-					'requires'    => array(
-						'id'       => 'caching',
-						'operator' => '==',
-						'value'    => 1,
-					),
-					'validation'  => array(
-						array(
-							'rule'    => 'min:1',
-							'message' => esc_html__( 'The cache duration must be at least 1 second.', 'gk-gravityview' ),
-						),
-					),
-					'title'       => esc_html__( 'DataTables Cache Duration', 'gk-gravityview' ),
-					'description' => esc_html__( 'Define the cache lifetime in seconds for DataTables output. Adjusting this setting can balance between performance gains and data currency for your DataTables Views.', 'gk-gravityview' ),
-					'value'       => $this->get( 'caching_datatables_output', $default_settings['caching_datatables_output'] ),
-				)
 			]
 		);
 

--- a/future/includes/class-gv-settings-plugin.php
+++ b/future/includes/class-gv-settings-plugin.php
@@ -244,8 +244,8 @@ class Plugin_Settings {
 
 		if ( ! empty( $cache_filters_in_use ) ) {
 			$notice = 1 === count( $cache_filters_in_use )
-				? esc_html__( 'Caching settings are being manually overridden by the [filter] filter.', 'gk-gravityview' )
-				: esc_html_x( 'Caching settings are being manually overridden by the following filters: [filters].', 'gk-gravityview' );
+				? esc_html_x( 'The [filter] active filter could be overriding cache settings.', 'Placeholders inside [] are not to be translated.', 'gk-gravityview' )
+				: esc_html_x( 'The following active filters could be overriding cache settings: [filters].', 'Placeholders inside [] are not to be translated.', 'gk-gravityview' );
 
 			$notice = strtr(
 				$notice,

--- a/future/includes/class-gv-settings-plugin.php
+++ b/future/includes/class-gv-settings-plugin.php
@@ -288,7 +288,7 @@ HTML;
 					'description' => strtr(
 						esc_html_x( '[url]Enabling caching[/url] improves performance by reducing the number of queries during page loads. When enabled, you can also specify cache duration for entries.', 'Placeholders inside [] are not to be translated.', 'gk-gravityview' ),
 						[
-							'[url]'  => '<a class="underline" href="https://docs.gravitykit.com/article/58-about-gravityview-caching" rel="noopener noreferrer">',
+							'[url]'  => '<a class="underline" href="https://docs.gravitykit.com/article/58-about-gravityview-caching" rel="noopener noreferrer" target="_blank">',
 							'[/url]' => '</a>',
 						]
 					),

--- a/future/includes/class-gv-settings-view.php
+++ b/future/includes/class-gv-settings-view.php
@@ -107,7 +107,7 @@ class View_Settings extends Settings {
 					'group'             => 'default',
 					'value'             => gravityview()->plugin->settings->get( 'caching' ),
 					'desc'              => strtr(
-						esc_html_x( 'Caching is enabled by default in the global [url]GravityView settings[/url]. Adjusting the settings here will allow you to manage caching on a per-View basis.', 'Placeholders inside [] are not to be translated.', 'gk-gravityview' ),
+						esc_html_x( 'Turn caching on or off to improve performance. Default settings are configured in [url]GravityView Caching Settings[/url].', 'Placeholders inside [] are not to be translated.', 'gk-gravityview' ),
 						[
 							'[url]'  => '<a href="' . esc_url( SettingsFramework::get_instance()->get_plugin_settings_url( Plugin_Settings::SETTINGS_PLUGIN_ID ) . '&s=1' ) . '">',
 							'[/url]' => '</a>',
@@ -121,7 +121,7 @@ class View_Settings extends Settings {
 				),
 				'caching_entries'             => array(
 					'label'             => __( 'Entry Cache Duration', 'gk-gravityview' ),
-					'tooltip'           => esc_html__( 'Specify the duration in seconds that entry data should remain cached before being refreshed. A shorter duration ensures more up-to-date data, while a longer duration improves performance.', 'gk-gravityview' ),
+					'tooltip'           => esc_html__( 'Specify the duration, in seconds, that entry data should remain cached before being refreshed. A shorter duration ensures more up-to-date data, while a longer duration improves performance.', 'gk-gravityview' ),
 					'type'              => 'number',
 					'group'             => 'default',
 					'value'             => gravityview()->plugin->settings->get( 'caching_entries' ),

--- a/future/includes/class-gv-settings-view.php
+++ b/future/includes/class-gv-settings-view.php
@@ -116,7 +116,7 @@ class View_Settings extends Settings {
 					'show_in_shortcode' => false,
 					'article'           => array(
 						'id'  => '54c67bb6e4b051242988550a',
-						'url' => 'https://docs.gravitykit.com/article/58-about-gravityview-cachinghttps://docs.gravitykit.com/article/58-about-gravityview-caching',
+						'url' => 'https://docs.gravitykit.com/article/58-about-gravityview-caching',
 					),
 				),
 				'caching_entries'             => array(

--- a/future/includes/class-gv-settings-view.php
+++ b/future/includes/class-gv-settings-view.php
@@ -1,6 +1,8 @@
 <?php
 namespace GV;
 
+use GravityKit\GravityView\Foundation\Settings\Framework as SettingsFramework;
+
 /** If this file is called directly, abort. */
 if ( ! defined( 'GRAVITYVIEW_DIR' ) ) {
 	die();
@@ -46,7 +48,6 @@ class View_Settings extends Settings {
 	 *      @param boolean $full_width True: Display the input and label together when rendering. False: Display label and input in separate columns when rendering.
 	 */
 	public static function defaults( $detailed = false, $group = null ) {
-
 		$default_settings = array_merge(
 			array(
 				'id'                          => array(
@@ -99,6 +100,34 @@ class View_Settings extends Settings {
 						'id'  => '5bad1a33042863158cc6d396',
 						'url' => 'https://docs.gravitykit.com/article/490-entry-approval-gravity-forms',
 					),
+				),
+				'caching'                     => array(
+					'label'             => __( 'Enable Caching', 'gk-gravityview' ),
+					'type'              => 'checkbox',
+					'group'             => 'default',
+					'value'             => gravityview()->plugin->settings->get( 'caching' ),
+					'desc'              => strtr(
+						esc_html_x( 'Caching is enabled by default in the global [url]GravityView settings[/url]. Adjusting the settings here will allow you to manage caching on a per-View basis.', 'Placeholders inside [] are not to be translated.', 'gk-gravityview' ),
+						[
+							'[url]'  => '<a href="' . SettingsFramework::get_instance()->get_plugin_settings_url( Plugin_Settings::SETTINGS_PLUGIN_ID ) . '&s=1">',
+							'[/url]' => '</a>',
+						]
+					),
+					'show_in_shortcode' => false,
+					'article'           => array(
+						'id'  => '54c67bb6e4b051242988550a',
+						'url' => 'https://docs.gravitykit.com/article/58-about-gravityview-cachinghttps://docs.gravitykit.com/article/58-about-gravityview-caching',
+					),
+				),
+				'caching_entries'             => array(
+					'label'             => __( 'Entry Cache Duration', 'gk-gravityview' ),
+					'tooltip'           => esc_html__( 'Specify the duration in seconds that entry data should remain cached before being refreshed. A shorter duration ensures more up-to-date data, while a longer duration improves performance.', 'gk-gravityview' ),
+					'type'              => 'number',
+					'group'             => 'default',
+					'value'             => gravityview()->plugin->settings->get( 'caching_entries' ),
+					'show_in_shortcode' => false,
+					'requires'          => 'caching=1',
+					'min'               => 1,
 				),
 				'no_entries_options'          => array(
 					'label'             => __( 'No Entries Behavior', 'gk-gravityview' ),

--- a/future/includes/class-gv-settings-view.php
+++ b/future/includes/class-gv-settings-view.php
@@ -109,7 +109,7 @@ class View_Settings extends Settings {
 					'desc'              => strtr(
 						esc_html_x( 'Caching is enabled by default in the global [url]GravityView settings[/url]. Adjusting the settings here will allow you to manage caching on a per-View basis.', 'Placeholders inside [] are not to be translated.', 'gk-gravityview' ),
 						[
-							'[url]'  => '<a href="' . SettingsFramework::get_instance()->get_plugin_settings_url( Plugin_Settings::SETTINGS_PLUGIN_ID ) . '&s=1">',
+							'[url]'  => '<a href="' . esc_url( SettingsFramework::get_instance()->get_plugin_settings_url( Plugin_Settings::SETTINGS_PLUGIN_ID ) . '&s=1' ) . '">',
 							'[/url]' => '</a>',
 						]
 					),

--- a/includes/admin/metaboxes/views/view-settings.php
+++ b/includes/admin/metaboxes/views/view-settings.php
@@ -15,12 +15,15 @@ $current_settings = gravityview_get_template_settings( $post->ID );
 
 <table class="form-table">
 <?php
-
 	GravityView_Render_Settings::render_setting_row( 'lightbox', $current_settings );
 
 	GravityView_Render_Settings::render_setting_row( 'show_only_approved', $current_settings );
 
 	GravityView_Render_Settings::render_setting_row( 'admin_show_all_statuses', $current_settings );
+
+	GravityView_Render_Settings::render_setting_row( 'caching', $current_settings );
+
+	GravityView_Render_Settings::render_setting_row( 'caching_entries', $current_settings );
 
 	do_action( 'gravityview_admin_directory_settings', $current_settings );
 ?>

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -476,7 +476,7 @@ class GravityView_Cache {
 
 		gravityview()->log->debug( 'Fetching request with transient key {key}', array( 'key' => $key ) );
 
-		$result = WPHelper::get_site_transient( $key );
+		$result = WPHelper::get_transient( $key );
 
 		if ( is_wp_error( $result ) ) {
 
@@ -542,7 +542,7 @@ class GravityView_Cache {
 			)
 		);
 
-		$transient_was_set = WPHelper::set_site_transient( $this->key, $content, $expiration );
+		$transient_was_set = WPHelper::set_transient( $this->key, $content, $expiration );
 
 		if ( ! $transient_was_set && $this->use_cache() ) {
 			gravityview()->log->error( 'Transient was not set for this key: ' . $this->key );

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -1,5 +1,7 @@
 <?php
 
+use GravityKit\GravityView\Foundation\Helpers\WP as WPHelper;
+
 /**
  * Handle caching using transients for GravityView
  */
@@ -9,6 +11,8 @@ class GravityView_Cache {
 	const BLACKLIST_OPTION_NAME = 'gravityview_cache_blocklist';
 
 	const BLOCKLIST_OPTION_NAME = 'gravityview_cache_blocklist';
+
+	const TRANSIENT_KEY_PREFIX = 'gv-cache-';
 
 	/**
 	 * Form ID, or array of Form IDs
@@ -267,7 +271,7 @@ class GravityView_Cache {
 
 		// Prefix for transient keys
 		// Now the prefix would be: `gv-cache-f:12-f:5-f:14-`
-		return 'gv-cache-' . $forms . '-';
+		return self::TRANSIENT_KEY_PREFIX . $forms . '-';
 	}
 
 	/**
@@ -472,7 +476,7 @@ class GravityView_Cache {
 
 		gravityview()->log->debug( 'Fetching request with transient key {key}', array( 'key' => $key ) );
 
-		$result = get_transient( $key );
+		$result = WPHelper::get_site_transient( $key );
 
 		if ( is_wp_error( $result ) ) {
 
@@ -538,7 +542,7 @@ class GravityView_Cache {
 			)
 		);
 
-		$transient_was_set = set_transient( $this->key, $content, $expiration );
+		$transient_was_set = WPHelper::set_site_transient( $this->key, $content, $expiration );
 
 		if ( ! $transient_was_set && $this->use_cache() ) {
 			gravityview()->log->error( 'Transient was not set for this key: ' . $this->key );
@@ -571,14 +575,14 @@ class GravityView_Cache {
 
 		foreach ( (array) $form_ids as $form_id ) {
 
-			$key = '_transient_gv-cache-';
+			$key = self::TRANSIENT_KEY_PREFIX;
 
 			$key = $wpdb->esc_like( $key );
 
 			$form_id = intval( $form_id );
 
 			// Find the transients containing this form
-			$key = "$key%f:$form_id-%"; // \_transient\_gv-cache-%f:1-% for example
+			$key = "$key%f:$form_id-%"; // gv-cache-%f:1-% for example
 			$sql = $wpdb->prepare( "SELECT option_name FROM {$wpdb->options} WHERE `option_name` LIKE %s", $key );
 
 			foreach ( ( $transients = $wpdb->get_col( $sql ) ) as $transient ) {
@@ -636,40 +640,49 @@ class GravityView_Cache {
 	public function delete_expired_transients() {
 		global $wpdb;
 
-		// Added this line, which isn't in the plugin
+		// Added this line, which isn't in the plugin.
 		$blog_id = get_current_blog_id();
 
-		$num_results = 0;
-
-		// get current PHP time, offset by a minute to avoid clashes with other tasks
+		// Get current PHP time, offset by a minute to avoid clashes with other tasks.
 		$threshold = time() - 60;
 
-		// get table name for options on specified blog
+		// Get table name for options on specified blog.
 		$table = $wpdb->get_blog_prefix( $blog_id ) . 'options';
 
-		// delete expired transients, using the paired timeout record to find them
-		$sql = "
-			delete from t1, t2
-			using $table t1
-			join $table t2 on t2.option_name = replace(t1.option_name, '_timeout', '')
-			where (t1.option_name like '\_transient\_timeout\_%' or t1.option_name like '\_site\_transient\_timeout\_%')
-			and t1.option_value < '$threshold'
-		";
+		// Delete expired GravityView <2.9.16 transients, using the paired timeout record to find them.
+		$sql = <<<SQL
+			DELETE FROM t1, t2
+			USING {$table} t1
+			JOIN {$table} t2 ON t2.option_name = replace(t1.option_name, '_timeout', '')
+			WHERE (t1.option_name LIKE '\_transient\_timeout\_%' OR t1.option_name LIKE '\_site\_transient\_timeout\_%')
+			AND t1.option_value < $threshold
+SQL;
 
 		$num_results = $wpdb->query( $sql );
 
-		// delete orphaned transient expirations
-		// also delete NextGEN Gallery 2.x display cache timeout aliases
-		$sql = "
-			delete from $table
-			where (
-				   option_name like '\_transient\_timeout\_%'
-				or option_name like '\_site\_transient\_timeout\_%'
-				or option_name like 'displayed\_galleries\_%'
-				or option_name like 'displayed\_gallery\_rendering\_%'
+		// Delete orphaned transient expirations.
+		// Also delete NextGEN Gallery 2.x display cache timeout aliases.
+		$sql = <<<SQL
+			DELETE FROM {$table}
+			WHERE (
+				   option_name LIKE '\_transient\_timeout\_%'
+				OR option_name LIKE '\_site\_transient\_timeout\_%'
+				OR option_name LIKE 'displayed\_galleries\_%'
+				OR option_name LIKE 'displayed\_gallery\_rendering\_%'
 			)
-			and option_value < '$threshold'
-		";
+			AND option_value < {$threshold}
+SQL;
+
+		$num_results += $wpdb->query( $sql );
+
+		// Delete expired GravityView >2.19.6 transients.
+		$key = self::TRANSIENT_KEY_PREFIX;
+
+		$sql = <<<SQL
+			DELETE FROM {$table}
+			WHERE option_name LIKE '{$key}%' AND
+			CAST(SUBSTRING_INDEX( SUBSTRING_INDEX(option_value, '"expiration";i:', -1), ';', 1 ) AS UNSIGNED INTEGER) <= {$threshold};
+SQL;
 
 		$num_results += $wpdb->query( $sql );
 

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -586,8 +586,7 @@ class GravityView_Cache {
 			$sql = $wpdb->prepare( "SELECT option_name FROM {$wpdb->options} WHERE `option_name` LIKE %s", $key );
 
 			foreach ( ( $transients = $wpdb->get_col( $sql ) ) as $transient ) {
-				// We have to delete it via the API to make sure the object cache is updated appropriately
-				delete_transient( preg_replace( '#^_transient_#', '', $transient ) );
+				WPHelper::delete_transient( $transient );
 			}
 
 			gravityview()->log->debug(

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -510,7 +510,7 @@ class GravityView_Cache {
 		// Don't cache empty results
 		if ( ! empty( $content ) ) {
 
-			$expiration = ! is_int( $expiration ) ? DAY_IN_SECONDS : $expiration;
+			$expiration = ! is_int( $expiration ) ? gravityview()->plugin->settings->get( "caching_{$filter_name}", DAY_IN_SECONDS ) : $expiration;
 
 			/**
 			 * Modify the cache time for a type of cache.
@@ -689,7 +689,7 @@ class GravityView_Cache {
 			return $this->use_cache;
 		}
 
-		$use_cache = true;
+		$use_cache = (bool) gravityview()->plugin->settings->get( 'caching' );
 
 		if ( GVCommon::has_cap( 'edit_gravityviews' ) ) {
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
+* Added: Global and View-specific settings to control caching of View entries
 * Added: Support for the [Advanced Post Creation Add-On](https://www.gravityforms.com/add-ons/advanced-post-creation/) when editing entries in GravityView's Edit Entry mode
 * Fixed: Deprecation notice in PHP 8.1+ when displaying a View with file upload fields
 

--- a/tests/unit-tests/GravityView_Field_Test.php
+++ b/tests/unit-tests/GravityView_Field_Test.php
@@ -116,6 +116,7 @@ class GravityView_Field_Test extends GV_UnitTestCase {
 	 */
 	function test_GravityView_Field_Other_Entries_get_entries() {
 		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+		add_filter( 'gravityview_use_cache', '__return_false' );
 
 		$form = $this->factory->form->import_and_get( 'complete.json' );
 		$post = $this->factory->view->create_and_get( array(
@@ -224,6 +225,7 @@ class GravityView_Field_Test extends GV_UnitTestCase {
 		$this->assertEquals( $valid_date_entry->ID, $entries[0]->ID );
 
 		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 	}
 
 	function test_GravityView_Field_Sequence() {
@@ -312,7 +314,8 @@ class GravityView_Field_Test extends GV_UnitTestCase {
 	}
 
 	function test_GravityView_Field_Sequence_single() {
-		add_filter( 'gk/gravityview/view/entries/cache', $disable_cache_filter = '__return_false' );
+		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+		add_filter( 'gravityview_use_cache', '__return_false' );
 
 		$form = $this->factory->form->import_and_get( 'simple.json' );
 		$post = $this->factory->view->create_and_get( array(
@@ -362,6 +365,7 @@ class GravityView_Field_Test extends GV_UnitTestCase {
 		$this->assertEquals( 1, $field->field->get_sequence( $context ) );
 
 		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 	}
 
 	function test_GravityView_Field_Unsubscribe_render_permissions() {

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -1690,6 +1690,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 
 		// Disable caching as we'll be running the same query but after creating new entries.
 		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+		add_filter( 'gravityview_use_cache', '__return_false' );
 
 		/** Some more */
 		foreach ( range( 1, 25 ) as $i ) {
@@ -1731,6 +1732,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 		remove_all_filters( 'gravityview/view/anchor_id' );
 		remove_all_filters( 'gravityview/widget/search/append_view_id_anchor' );
 		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 	}
 
     /**
@@ -1807,6 +1809,7 @@ class GVFuture_Test extends GV_UnitTestCase {
         add_filter( 'gravityview/view/anchor_id', '__return_false' );
         add_filter( 'gravityview/widget/search/append_view_id_anchor', '__return_false' );
 		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+		add_filter( 'gravityview_use_cache', '__return_false' );
 
 		gravityview()->request = new \GV\Mock_Request();
 		gravityview()->request->returns['is_view'] = $view;
@@ -1985,6 +1988,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 		remove_all_filters( 'gravityview/view/anchor_id' );
 		remove_all_filters( 'gravityview/widget/search/append_view_id_anchor' );
 		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 	}
 
 	/**
@@ -2166,6 +2170,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 		$form = $this->factory->form->import_and_get( 'complete.json' );
 
 		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+		add_filter( 'gravityview_use_cache', '__return_false' );
 
 		global $post;
 
@@ -2244,6 +2249,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 		remove_all_filters( 'gravityview/view/anchor_id' );
 		remove_all_filters( 'gravityview/widget/search/append_view_id_anchor' );
 		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 	}
 
 	/**
@@ -2955,6 +2961,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 
 		// Disable caching as we'll be running the same query but after creating new entries.
 		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+		add_filter( 'gravityview_use_cache', '__return_false' );
 
 		$entry_2 = $this->factory->entry->create_and_get( array(
 			'form_id' => $form['id'],
@@ -2981,6 +2988,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 		unset( $GLOBALS['post'] );
 
 		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 	}
 
 	/**
@@ -5213,6 +5221,9 @@ class GVFuture_Test extends GV_UnitTestCase {
 	 * @covers \GravityView_Shortcode::shortcode()
 	 */
 	public function test_shortcodes_gravityview() {
+		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+		add_filter( 'gravityview_use_cache', '__return_false' );
+
 		$form = $this->factory->form->import_and_get( 'complete.json' );
 
 		$post = $this->factory->view->create_and_get( array(
@@ -5332,6 +5343,8 @@ class GVFuture_Test extends GV_UnitTestCase {
 
 		remove_all_filters( 'gravityview/view/anchor_id' );
 		remove_all_filters( 'gravityview/widget/search/append_view_id_anchor' );
+		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 	}
 
 	/**

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -5929,7 +5929,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 		$settings->update( array() );
 
 		$this->assertSame( \GravityView_Settings::get_instance(), $settings );
-		$this->assertEquals( array_keys( $settings->defaults() ), array( 'rest_api', 'public_entry_moderation' ) );
+		$this->assertEquals( array_keys( $settings->defaults() ), array( 'rest_api', 'public_entry_moderation', 'caching', 'caching_entries', 'caching_datatables_output' ) );
 
 		$this->assertNull( $settings->get( 'not' ) );
 		$this->assertEquals( $settings->get( 'not', 'default' ), 'default' );

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -5942,7 +5942,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 		$settings->update( array() );
 
 		$this->assertSame( \GravityView_Settings::get_instance(), $settings );
-		$this->assertEquals( array_keys( $settings->defaults() ), array( 'rest_api', 'public_entry_moderation', 'caching', 'caching_entries', 'caching_datatables_output' ) );
+		$this->assertEquals( array_keys( $settings->defaults() ), array( 'rest_api', 'public_entry_moderation', 'caching', 'caching_entries' ) );
 
 		$this->assertNull( $settings->get( 'not' ) );
 		$this->assertEquals( $settings->get( 'not', 'default' ), 'default' );

--- a/tests/unit-tests/GravityView_Joins_Test.php
+++ b/tests/unit-tests/GravityView_Joins_Test.php
@@ -287,6 +287,7 @@ class GravityView_Joins_Test extends GV_UnitTestCase {
 
 	public function test_joins_with_approves() {
 		add_filter('gk/gravityview/view/entries/cache', '__return_false');
+		add_filter('gravityview_use_cache', '__return_false');
 
 		$this->_reset_context();
 
@@ -376,6 +377,7 @@ class GravityView_Joins_Test extends GV_UnitTestCase {
 		$this->_reset_context();
 
 		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 	}
 
 	public function test_legacy_template_table_joins() {

--- a/tests/unit-tests/GravityView_Shortcode_Test.php
+++ b/tests/unit-tests/GravityView_Shortcode_Test.php
@@ -52,6 +52,7 @@ class GravityView_Shortcode_Test extends GV_UnitTestCase {
 
 		// Disable caching as we'll be running the same query but after creating new entries.
 		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+		add_filter( 'gravityview_use_cache', '__return_false' );
 
 		foreach ( range( 1, 50 ) as $i ) {
 			$entry = $this->factory->entry->create_and_get( array(
@@ -71,6 +72,7 @@ class GravityView_Shortcode_Test extends GV_UnitTestCase {
 		$this->assertEquals( '10', $value );
 
 		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 
 		$view->settings->update( array(
 			'offset' => 20,
@@ -131,6 +133,7 @@ class GravityView_Shortcode_Test extends GV_UnitTestCase {
 
 		// Disable caching as we'll be running the same query but after creating new entries.
 		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+		add_filter( 'gravityview_use_cache', '__return_false' );
 
 		foreach ( range( 1, 1050 ) as $i ) {
 			$entry = $this->factory->entry->create_and_get( array(
@@ -151,6 +154,7 @@ class GravityView_Shortcode_Test extends GV_UnitTestCase {
 		gravityview()->request = new \GV\Frontend_Request();
 
 		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 	}
 
 	/**

--- a/tests/unit-tests/GravityView_Widget_Search_Test.php
+++ b/tests/unit-tests/GravityView_Widget_Search_Test.php
@@ -957,6 +957,7 @@ class GravityView_Widget_Search_Test extends GV_UnitTestCase {
 		$this->assertEquals( 0, $view->get_entries()->count() );
 
 		add_filter( 'gk/gravityview/view/entries/cache', '__return_false' );
+		add_filter( 'gravityview_use_cache', '__return_false' );
 
 		update_user_meta( $gamma, 'custom_meta', 'custom' );
 		add_filter( 'gravityview/widgets/search/created_by/user_meta_fields', function() {
@@ -966,6 +967,7 @@ class GravityView_Widget_Search_Test extends GV_UnitTestCase {
 
 		remove_all_filters( 'gravityview/widgets/search/created_by/user_meta_fields' );
 		remove_all_filters( 'gk/gravityview/view/entries/cache' );
+		remove_all_filters( 'gravityview_use_cache' );
 
 		$_GET = array();
 	}


### PR DESCRIPTION
This adds a global (GravityKit > Settings > GravityView) and View setting to control caching. This also implements long-lived caching (https://docs.gravitykit.com/article/58-about-gravityview-caching) that we haven't had since... ages.

Ref: #1818.