### PR TITLE
Only show notice when a form is set

### DIFF
--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-advanced-post-creation.php
@@ -88,7 +88,11 @@ final class GravityView_Plugin_Hooks_Gravity_Forms_Advanced_Post_Creation extend
 			return null;
 		}
 
-		$form  = $view->form;
+		$form = $view->form;
+		if ( ! $form ) {
+			return null;
+		}
+		
 		$apc   = GF_Advanced_Post_Creation::get_instance();
 		$feeds = $apc->get_active_feeds( $form->ID );
 


### PR DESCRIPTION
On a new view without a connected form, this page showed a warning.