### PR TITLE
Support for nested forms entry meta

### DIFF
--- a/includes/fields/class-gravityview-field-gravityview_view.php
+++ b/includes/fields/class-gravityview-field-gravityview_view.php
@@ -164,44 +164,47 @@ class GravityView_Field_GravityView_View extends GravityView_Field {
 			return;
 		}
 
-		$attributes = '';
+		$attributes = [ 'post_id' => $post->ID ];
 
 		$page_size_value = \GV\Utils::get( $field_settings, 'page_size', 'default' );
-		$attributes     .= ( 'default' === $page_size_value ) ? '' : sprintf( ' page_size="%d"', $page_size_value );
+		if ( 'default' !== $page_size_value ) {
+			$attributes['page_size'] = (int) $page_size_value;
+		}
 
 		// Prepare search field.
 		$search_field = \GV\Utils::get( $field_settings, 'search_field' );
 		if ( ! is_null( $search_field ) ) {
-			$attributes .= sprintf( ' search_field="%s"', esc_attr( $search_field ) );
+			$attributes['search_field'] = esc_attr( $search_field );
 		}
 
 		$search_value = \GV\Utils::get( $field_settings, 'search_value' );
 		if ( ! is_null( $search_value ) ) {
-			$search_value = GFCommon::replace_variables( $search_value, $form, $context->entry->as_entry() );
-			$attributes  .= sprintf( ' search_value="%s"', esc_attr( $search_value ) );
+			$search_value               = GFCommon::replace_variables( $search_value, $form, $context->entry->as_entry() );
+			$attributes['search_value'] = esc_attr( $search_value );
 		}
 
 		// Prepare search operator.
 		$search_operator = \GV\Utils::get( $field_settings, 'search_operator' );
 		if ( ! is_null( $search_operator ) ) {
-			$attributes .= sprintf( ' search_operator="%s"', esc_attr( $search_operator ) );
+			$attributes['search_operator'] = esc_attr( $search_operator );
 		}
 
 		// Start date
 		$start_date = \GV\Utils::get( $field_settings, 'start_date' );
 		if ( ! empty( $start_date ) ) {
-			$start_date  = GFCommon::replace_variables( $start_date, $form, $context->entry->as_entry() );
-			$attributes .= sprintf( ' start_date="%s"', esc_attr( $start_date ) );
+			$start_date               = GFCommon::replace_variables( $start_date, $form, $context->entry->as_entry() );
+			$attributes['start_date'] = esc_attr( $start_date );
 		}
 
 		// End date
 		$end_date = \GV\Utils::get( $field_settings, 'end_date' );
 		if ( ! empty( $end_date ) ) {
-			$end_date    = GFCommon::replace_variables( $end_date, $form, $context->entry->as_entry() );
-			$attributes .= sprintf( ' end_date="%s"', esc_attr( $end_date ) );
+			$end_date               = GFCommon::replace_variables( $end_date, $form, $context->entry->as_entry() );
+			$attributes['end_date'] = esc_attr( $end_date );
 		}
 
-		$shortcode = sprintf( '[gravityview id="%d" post_id="%d" %s /]', $view_id, $post->ID, trim( $attributes ) );
+		$view      = \GV\View::by_id( $view_id );
+		$shortcode = $view->get_shortcode( $attributes );
 
 		echo do_shortcode( $shortcode );
 	}

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-perks-nested-forms.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-perks-nested-forms.php
@@ -29,6 +29,13 @@ final class GravityView_Plugin_Hooks_Gravity_Perks_Nested_Forms extends GravityV
 			Closure::fromCallable( [ $this, 'add_custom_gpnf_merge_tags' ] ),
 			10
 		);
+
+		add_filter(
+			'gravityview_entry_default_fields',
+			Closure::fromCallable( [ $this, 'add_entry_field' ] ),
+			10,
+			3
+		);
 	}
 
 	/**
@@ -68,6 +75,40 @@ final class GravityView_Plugin_Hooks_Gravity_Perks_Nested_Forms extends GravityV
 				'tag'   => '{Parent:form_id}',
 			],
 		] );
+	}
+
+	/**
+	 * Add fields to GravityView.
+	 * @since $ver$
+	 *
+	 * @param array        $fields The fields.
+	 * @param string|array $form   THe form reference.
+	 * @param string       $zone   The zone.
+	 *
+	 * @return array The updated fields.
+	 */
+	private function add_entry_field( array $fields, $form, string $zone ): array {
+		if ( ! in_array( $zone, [ 'directory', 'single' ] ) ) {
+			return $fields;
+		}
+
+		$fields[ GPNF_Entry::ENTRY_PARENT_KEY ] = [
+			'label' => esc_html__( 'Parent Entry ID', 'gp-nested-forms' ),
+			'desc'  => esc_html__( 'The parent entry ID for nested form entries.', 'gk-gravityview' ),
+			'type'  => GPNF_Entry::ENTRY_PARENT_KEY,
+			'group' => 'add-on',
+			'icon'  => 'dashicons-code-standards',
+		];
+
+		$fields[ GPNF_Entry::ENTRY_PARENT_FORM_KEY ] = [
+			'label' => esc_html__( 'Parent Entry Form ID', 'gp-nested-forms' ),
+			'desc'  => esc_html__( 'The parent form ID for this nested form entry.', 'gk-gravityview' ),
+			'type'  => 'gpnf_entry_parent',
+			'group' => 'add-on',
+			'icon'  => 'dashicons-code-standards',
+		];
+
+		return $fields;
 	}
 }
 

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-perks-nested-forms.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-perks-nested-forms.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Handles custom hooks for Gravity Perks Nested Forms.
+ * @since $ver$
+ */
+final class GravityView_Plugin_Hooks_Gravity_Perks_Nested_Forms extends GravityView_Plugin_and_Theme_Hooks {
+	/**
+	 * @inheritDoc
+	 * @since $ver$
+	 */
+	protected $class_name = GPNF_Parent_Merge_Tag::class;
+
+	/**
+	 * @inheritDoc
+	 * @since $ver$
+	 */
+	protected function add_hooks() {
+		parent::add_hooks();
+
+		add_filter(
+			'gravityview/merge_tags/do_replace_variables',
+			Closure::fromCallable( [ $this, 'add_gpnf_merge_tags' ] ),
+			5
+		);
+	}
+
+	/**
+	 * Add GP Nested forms merge tags for Gravity View.
+	 * @since $ver$
+	 * @return bool
+	 */
+	private function add_gpnf_merge_tags($value) {
+		add_filter( 'gform_replace_merge_tags', [
+			GPNF_Parent_Merge_Tag::get_instance(),
+			'parse_parent_merge_tag',
+		], 5, 7 );
+
+		remove_filter( 'gform_replace_merge_tags', [
+			GPNF_Parent_Merge_Tag::get_instance(),
+			'parse_parent_merge_tag',
+		], 6 );
+
+		return $value;
+	}
+}
+
+new GravityView_Plugin_Hooks_Gravity_Perks_Nested_Forms();

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-perks-nested-forms.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-perks-nested-forms.php
@@ -74,6 +74,10 @@ final class GravityView_Plugin_Hooks_Gravity_Perks_Nested_Forms extends GravityV
 				'label' => esc_html__( 'Parent Entry Form ID', 'gp-nested-forms' ),
 				'tag'   => '{Parent:form_id}',
 			],
+			[
+				'label' => esc_html__( 'Child Form Field ID', 'gp-nested-forms' ),
+				'tag'   => '{Parent:child_id}',
+			],
 		] );
 	}
 
@@ -88,7 +92,7 @@ final class GravityView_Plugin_Hooks_Gravity_Perks_Nested_Forms extends GravityV
 	 * @return array The updated fields.
 	 */
 	private function add_entry_field( array $fields, $form, string $zone ): array {
-		if ( ! in_array( $zone, [ 'directory', 'single' ] ) ) {
+		if ( ! in_array( $zone, [ 'directory', 'single' ], true ) ) {
 			return $fields;
 		}
 
@@ -103,7 +107,15 @@ final class GravityView_Plugin_Hooks_Gravity_Perks_Nested_Forms extends GravityV
 		$fields[ GPNF_Entry::ENTRY_PARENT_FORM_KEY ] = [
 			'label' => esc_html__( 'Parent Entry Form ID', 'gp-nested-forms' ),
 			'desc'  => esc_html__( 'The parent form ID for this nested form entry.', 'gk-gravityview' ),
-			'type'  => 'gpnf_entry_parent',
+			'type'  => GPNF_Entry::ENTRY_PARENT_FORM_KEY,
+			'group' => 'add-on',
+			'icon'  => 'dashicons-code-standards',
+		];
+
+		$fields[ GPNF_Entry::ENTRY_NESTED_FORM_FIELD_KEY ] = [
+			'label' => esc_html__( 'Child Form Field ID', 'gp-nested-forms' ),
+			'desc'  => esc_html__( 'The field ID on the parent form for this nested form.', 'gk-gravityview' ),
+			'type'  => GPNF_Entry::ENTRY_NESTED_FORM_FIELD_KEY,
 			'group' => 'add-on',
 			'icon'  => 'dashicons-code-standards',
 		];

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-perks-nested-forms.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-perks-nested-forms.php
@@ -23,6 +23,12 @@ final class GravityView_Plugin_Hooks_Gravity_Perks_Nested_Forms extends GravityV
 			Closure::fromCallable( [ $this, 'add_gpnf_merge_tags' ] ),
 			5
 		);
+
+		add_filter(
+			'gform_custom_merge_tags',
+			Closure::fromCallable( [ $this, 'add_custom_gpnf_merge_tags' ] ),
+			10
+		);
 	}
 
 	/**
@@ -30,7 +36,7 @@ final class GravityView_Plugin_Hooks_Gravity_Perks_Nested_Forms extends GravityV
 	 * @since $ver$
 	 * @return bool
 	 */
-	private function add_gpnf_merge_tags($value) {
+	private function add_gpnf_merge_tags( $value ) {
 		add_filter( 'gform_replace_merge_tags', [
 			GPNF_Parent_Merge_Tag::get_instance(),
 			'parse_parent_merge_tag',
@@ -42,6 +48,26 @@ final class GravityView_Plugin_Hooks_Gravity_Perks_Nested_Forms extends GravityV
 		], 6 );
 
 		return $value;
+	}
+
+	/**
+	 * Adds the merge tags for
+	 *
+	 * @param array $tags The registered tags.
+	 *
+	 * @return array
+	 */
+	private function add_custom_gpnf_merge_tags( array $tags ): array {
+		return array_merge( $tags, [
+			[
+				'label' => esc_html__( 'Parent Entry ID', 'gp-nested-forms' ),
+				'tag'   => '{Parent:entry_id}',
+			],
+			[
+				'label' => esc_html__( 'Parent Entry Form ID', 'gp-nested-forms' ),
+				'tag'   => '{Parent:form_id}',
+			],
+		] );
 	}
 }
 


### PR DESCRIPTION
This PR addresses #1892. 

Basically everything asked for in that issue is solved. But to reference the parent in the merge tags you need to use: `{Parent:<field>}` So `{Parent:1.2}` or `{Parent:entry_id}` or `{Parent:form_id}`.

And to be able to connect in the view search field you need to search for  the key `gpnf_entry_parent` or `gpnf_entry_parent_form`.

💾 [Build file](https://www.dropbox.com/scl/fi/jgdhs9mnmju6uxqaji8o5/gravityview-2.22-7f95583e8.zip?rlkey=svggtxibwx92eulbdzg045bgs&dl=1) (7f95583e8).