### PR TITLE
Fix export link widget by sanitizing link

### DIFF
--- a/includes/widgets/class-gravityview-widget-export-link.php
+++ b/includes/widgets/class-gravityview-widget-export-link.php
@@ -200,7 +200,7 @@ HTML;
 
 		$link = $in_paragraph ? sprintf( '<p>%s</p>', $link ) : $link;
 
-		printf( '<div class="gv-widget-export-link %s">' . $link . '</div>', gravityview_sanitize_html_class( $classes ) );
+		printf( '<div class="gv-widget-export-link %s">%s</div>', gravityview_sanitize_html_class( $classes ), $link );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 #### 🐛 Fixed
-* Export link widget would cause fatal error when search on multiple words.
+* Export link widget would cause fatal error when searching on multiple words.
 
 = 2.22 on April 16, 2024 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+#### 🐛 Fixed
+* Export link widget would cause fatal error when search on multiple words.
+
 = 2.22 on April 16, 2024 =
 
 This release introduces [support for search modifiers](https://docs.gravitykit.com/article/995-gravityview-search-modifiers) and [range-based searching for numeric fields](https://docs.gravitykit.com/article/996-number-range-search), enables easy duplication and precise insertion of View fields and widgets, and resolves critical issues with Yoast SEO and LifterLMS. [Read the announcement](https://www.gravitykit.com/gravityview-2-22/) for more details.


### PR DESCRIPTION
This PR addresses #2034 where the export link widget would cause a fatal error when searching on multiple words. 

The problem is that the space between the words is transformed into `%20`. And because the link is added to the `printf` function directly it reads that `%` as a placeholder. 

Fixed it by adding the link via a `%s` placeholder as well.