### PR TITLE
Use date range filter on View widget

### DIFF
--- a/includes/widgets/class-gravityview-widget-export-link.php
+++ b/includes/widgets/class-gravityview-widget-export-link.php
@@ -172,7 +172,7 @@ HTML;
 		$page_query_params = array_filter(
 			$_GET,
 			static function ( $value, string $key ): bool {
-				return 'mode' === $key || preg_match( '/^filter_?/i', $key );
+				return 'mode' === $key || preg_match( '/^(gv|filter)_?/i', $key );
 			},
 			ARRAY_FILTER_USE_BOTH
 		);

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -219,6 +219,7 @@ class GravityView_Widget_Search extends \GV\Widget {
 			'address'    => array( 'input_text' ),
 			'number'     => array( 'input_text', 'number_range' ),
 			'date'       => array( 'date', 'date_range' ),
+			'entry_date' => array( 'date_range' ),
 			'boolean'    => array( 'single_checkbox' ),
 			'select'     => array( 'select', 'radio', 'link' ),
 			'multi'      => array( 'select', 'multiselect', 'radio', 'checkbox', 'link' ),
@@ -387,7 +388,7 @@ class GravityView_Widget_Search extends \GV\Widget {
 			),
 			'entry_date' => array(
 				'text' => esc_html__( 'Entry Date', 'gk-gravityview' ),
-				'type' => 'date',
+				'type' => 'entry_date',
 			),
 			'entry_id'   => array(
 				'text' => esc_html__( 'Entry ID', 'gk-gravityview' ),

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+#### 🐛 Fixed
+* Export link View widget would not use date range filters.
+
 = 2.23 on May 17, 2024 =
 
 This update adds support for Nested Forms' entry meta, addresses several bugs, including critical ones, and improves GravityKit's Settings and Manage Your Kit screens.

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 #### 🐛 Fixed
 * Export link View widget would not use date range filters.
+* The Entry Date Search Field could select a "Date" input type which is not supported.
 
 = 2.23 on May 17, 2024 =
 


### PR DESCRIPTION
This PR Addresses #2053. The date range (and global search) is prefixed with `gv_` instead of `filter_`. These values are now also extracted and passed along to the CSV download url.

💾 [Build file](https://www.dropbox.com/scl/fi/ap53hk13mu1he3e7pnmrb/gravityview-2.23-a288e7e63.zip?rlkey=10fslr0z107w9qxuw7b6y3f47&dl=1) (a288e7e63).