### PR TITLE
Fix product field search with text

### DIFF
--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -1089,7 +1089,7 @@ class GravityView_Widget_Search extends \GV\Widget {
 						$left  = new GF_Query_Column( $left->field_id, $left->source, $alias );
 					}
 
-					if ( $this->is_product_field( $filter ) ) {
+					if ( $this->is_product_field( $filter ) && ( $filter['is_numeric'] ?? false ) ) {
 						$original_left = clone $left;
 						$column        = $left instanceof GF_Query_Call ? $left->columns[0] ?? null : $left;
 						$column_name   = sprintf( '`%s`.`%s`', $column->alias, $column->is_entry_column() ? $column->field_id : 'meta_value' );

--- a/includes/widgets/search-widget/templates/search-field-input_text.php
+++ b/includes/widgets/search-widget/templates/search-field-input_text.php
@@ -8,6 +8,10 @@
 $gravityview_view = GravityView_View::getInstance();
 $search_field     = $gravityview_view->search_field;
 
+if ( ! is_string( $search_field['value'] ?? '' ) ) {
+	$search_field['value'] = '';
+}
+
 ?>
 <div class="gv-search-box gv-search-field-text">
 	<?php if ( ! gv_empty( $search_field['label'], false, false ) ) { ?>

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+#### 🐛 Fixed
+* Searching for products only worked for price ranges.
+
 = 2.23 on May 17, 2024 =
 
 This update adds support for Nested Forms' entry meta, addresses several bugs, including critical ones, and improves GravityKit's Settings and Manage Your Kit screens.

--- a/tests/unit-tests/GravityView_Widget_Search_Test.php
+++ b/tests/unit-tests/GravityView_Widget_Search_Test.php
@@ -1830,7 +1830,7 @@ class GravityView_Widget_Search_Test extends GV_UnitTestCase {
 				'form_id' => $form['id'],
 				'status'  => 'active',
 				'9'       => $number,
-				'26'      => 'product name|' . $currency_symbol . $number,
+				'26'      => 'product name ' . $number . '|' . $currency_symbol . $number,
 			) );
 		}
 
@@ -1876,6 +1876,14 @@ class GravityView_Widget_Search_Test extends GV_UnitTestCase {
 
 		$_GET = [ 'filter_26' => [ 'min' => -20, 'max' => 7 ], 'mode' => 'all' ];
 		$this->assertEquals( 3, $view->get_entries()->count() );
+
+		// Make sure searching on text still works.
+		$_GET = ['filter_26' => 'product'];
+		$this->assertEquals( 5, $view->get_entries()->count() );
+
+		$_GET = ['filter_26' => 'name 7'];
+		$this->assertEquals( 1, $view->get_entries()->count() );
+
 
 		$_GET = array();
 	}


### PR DESCRIPTION
This PR Addresses #2063 

The check only looked for product fields, but did not take into account it could just be searching for a text. When using a Range, the filters are set to `is_numeric`. This is now added to the check to be sure it still searches on text too.

Tests added to prevent future regression.

💾 [Build file](https://www.dropbox.com/scl/fi/9i1s1ocvommim4tkhcy40/gravityview-2.23-6bfe2cd5d.zip?rlkey=ueaiujhl48craxg5qvrxvbpo7&dl=1) (6bfe2cd5d).