### PR TITLE
Trigger "gform_pre_render" before sending notifications

### DIFF
--- a/includes/class-gravityview-notifications.php
+++ b/includes/class-gravityview-notifications.php
@@ -42,6 +42,10 @@ final class GravityView_Notifications {
 			return;
 		}
 
+		if ( $form ) {
+			$form = gf_apply_filters( [ 'gform_pre_render', $form['id'] ], $form, false, [] );
+		}
+
 		GFAPI::send_notifications( $form, $entry, $event );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * Product search now returns correct results when using all search input types.
 * View's Export Link widget would not respect date range search filters.
 * Removed the unsupported "date" input type for the Date Entry field under the Search Bar's settings.
+* Merge tags in GravityView notifications are now properly processed for fields dynamically populated by Gravity Wiz's Populate Anything add-on.
 
 #### 💻 Developer Updates
 * Added `gk/gravityview/field/is-read/print-script` filter to modify whether to print the script in the frontend that marks an entry as "Read".


### PR DESCRIPTION
This fixes #2060 where merge tags for fields populated by Populate Anything return values rather than labels.

💾 [Build file](https://www.dropbox.com/scl/fi/upe3grhmccamhy49phjle/gravityview-2.23-c0b265973.zip?rlkey=yye9aer0tki7ibx06ttuyb0mc&dl=1) (c0b265973).