### PR TITLE
Issue/search mode toggle event

### DIFF
--- a/assets/js/admin-shortcode.js
+++ b/assets/js/admin-shortcode.js
@@ -3,15 +3,15 @@
  * @since 2.21
  */
 ( function ( $ ) {
-	$( document ).ready( function () {
-		var shortcode_clipboard = new ClipboardJS( '.gv-shortcode input.code', {
+	$( function () {
+		const shortcode_clipboard = new ClipboardJS( '.gv-shortcode input.code', {
 			text: function ( trigger ) {
 				return $( trigger ).val();
 			}
 		} );
 
 		shortcode_clipboard.on('success', function (e) {
-			var $el = $( e.trigger ).closest( '.gv-shortcode' ).find( '.copied' );
+			const $el = $( e.trigger ).closest( '.gv-shortcode' ).find( '.copied' );
 			$el.show();
 			setTimeout( function () {
 				$el.fadeOut();

--- a/assets/js/admin-shortcode.js
+++ b/assets/js/admin-shortcode.js
@@ -1,9 +1,9 @@
-/**
+	/**
  * Responsible for copying the short codes from the list and edit page.
  * @since 2.21
  */
 ( function ( $ ) {
-	$( document ).on( 'ready', function () {
+	$( document ).ready( function () {
 		var shortcode_clipboard = new ClipboardJS( '.gv-shortcode input.code', {
 			text: function ( trigger ) {
 				return $( trigger ).val();

--- a/assets/js/admin-shortcode.js
+++ b/assets/js/admin-shortcode.js
@@ -1,4 +1,4 @@
-	/**
+/**
  * Responsible for copying the short codes from the list and edit page.
  * @since 2.21
  */

--- a/includes/widgets/search-widget/assets/js/source/admin-search-widget.js
+++ b/includes/widgets/search-widget/assets/js/source/admin-search-widget.js
@@ -530,7 +530,7 @@
 
 			var options = gvSearchWidget.getSelectInput( type );
 
-			select.html( options );
+			select.html( options ).trigger( 'change' );
 
 			// If there's only one option, disable ability to change it.
 			select.prop( 'disabled', function () {

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 #### 🐛 Fixed
 * Timeout issue when rendering a page/post with GravityView Gutenberg blocks when Yoast SEO is active.
 * View editor fields added to the Single or Edit Entry layouts inheriting options from the View type set in the Multiple Entries layout.
+* Search Widget issue where the Search Mode was fixed and disabled after selecting a Date Field.
 
 = 2.25 on June 5, 2024 =
 


### PR DESCRIPTION
This PR resolves an issue where the search mode is not updated when a field is changed. Triggering the change event retries the toggle calculation so it works again.

https://www.loom.com/share/7954e41fdfa94e588747f7c17401d0d0



💾 [Build file](https://www.dropbox.com/scl/fi/5p6rojlxqzaf3ys0wl0vn/gravityview-2.25-80d215dd2.zip?rlkey=fgff002f8cfrrrrqwolfus25c&dl=1) (80d215dd2).