### PR TITLE
Removes the filter that removed gf max files validation

### DIFF
--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -156,9 +156,6 @@ class GravityView_Edit_Entry_Render {
 		// Disable conditional logic if needed (since 1.9)
 		add_filter( 'gform_has_conditional_logic', array( $this, 'manage_conditional_logic' ), 10, 2 );
 
-		// Make sure GF doesn't validate max files (since 1.9)
-		add_filter( 'gform_plupload_settings', array( $this, 'modify_fileupload_settings' ), 10, 3 );
-
 		// Add fields expected by GFFormDisplay::validate()
 		add_filter( 'gform_pre_validation', array( $this, 'gform_pre_validation' ) );
 
@@ -634,26 +631,6 @@ class GravityView_Edit_Entry_Render {
 
 		return $value;
 	}
-
-	/**
-	 * Remove max_files validation (done on gravityforms.js) to avoid conflicts with GravityView
-	 * Late validation done on self::custom_validation
-	 *
-	 * @param $plupload_init array Plupload settings
-	 * @param $form_id
-	 * @param $instance
-	 * @return mixed
-	 */
-	public function modify_fileupload_settings( $plupload_init, $form_id, $instance ) {
-		if ( ! $this->is_edit_entry() ) {
-			return $plupload_init;
-		}
-
-		$plupload_init['gf_vars']['max_files'] = 0;
-
-		return $plupload_init;
-	}
-
 
 	/**
 	 * Set visibility to visible and convert field input key to string


### PR DESCRIPTION
- This solves https://github.com/GravityKit/GravityView/issues/2086
- The edit entry validation for max files works but after the user clicks edit entry.
- The issue here is the files are uploaded to the uploads folder before they are validated
- Gravity forms already has a good ajax validation for this part but we have a filter that removes that validation in GravityView 
`add_filter( 'gform_plupload_settings', array( $this, 'modify_fileupload_settings' ), 10, 3 );`
- It says that it was added because our custom validation already handles that so we don't have a conflict ( I tried to find that conflict but couldn't)
- So we can leave it as it is and we would have ajax validation (gf validation) and also a custom validation after the user clicks update (Our validation)
- Or we can keep the filter that removes gf validation and build our own.