### PR TITLE
Use local timezone when formatting Time fields

### DIFF
--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -181,8 +181,12 @@ class GravityView_Merge_Tags {
 	 * @return string
 	 */
 	private static function modifier_format( $raw_value, $matches, $value, $field, $modifier ) {
-		if ( ( $field instanceof GF_Field_Date || $field instanceof GF_Field_Time ) && $modifier ) {
-			return self::format_date( $raw_value, $modifier );
+		$format = self::get_format_merge_tag_modifier_value( $modifier );
+
+		if ( $format && $field instanceof GF_Field_Time ) {
+			$raw_value = ( new DateTime( $raw_value ) )->format( $format ); // GF's Time field always uses local time.
+		} elseif ( $format && $field instanceof GF_Field_Date ) {
+			$raw_value = self::format_date( $raw_value, $modifier );
 		}
 
 		return $raw_value;

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -183,10 +183,16 @@ class GravityView_Merge_Tags {
 	private static function modifier_format( $raw_value, $matches, $value, $field, $modifier ) {
 		$format = self::get_format_merge_tag_modifier_value( $modifier );
 
-		if ( $format && $field instanceof GF_Field_Time ) {
-			$raw_value = ( new DateTime( $raw_value ) )->format( $format ); // GF's Time field always uses local time.
-		} elseif ( $format && $field instanceof GF_Field_Date ) {
-			$raw_value = self::format_date( $raw_value, $modifier );
+		if ( ! $format ) {
+			return $raw_value;
+		}
+
+		if ( $field instanceof GF_Field_Time ) {
+			return ( new DateTime( $raw_value ) )->format( $format ); // GF's Time field always uses local time.
+		}
+
+		if ( $field instanceof GF_Field_Date ) {
+			return self::format_date( $raw_value, $modifier );
 		}
 
 		return $raw_value;

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -95,15 +95,10 @@ class GravityView_Merge_Tags {
 
 		// matching regex => the value is the method to call to replace the value.
 		$gv_modifiers = array(
-			'maxwords:(\d+)'            => 'modifier_maxwords',
-			/** @see modifier_maxwords */
-							'timestamp' => 'modifier_timestamp',
-			/** @see modifier_timestamp */
-							'explode'   => 'modifier_explode',
-			/** @see modifier_explode */
-
-							/** @see modifier_strings */
-							'urlencode' => 'modifier_strings',
+			'maxwords:(\d+)'            => 'modifier_maxwords', /** @see modifier_maxwords */
+			'timestamp'                 => 'modifier_timestamp', /** @see modifier_timestamp */
+			'explode'                   => 'modifier_explode', /** @see modifier_explode */
+			'urlencode'                 => 'modifier_strings', /** @see modifier_strings */
 			'wpautop'                   => 'modifier_strings',
 			'esc_html'                  => 'modifier_strings',
 			'sanitize_html_class'       => 'modifier_strings',
@@ -113,7 +108,7 @@ class GravityView_Merge_Tags {
 			'ucfirst'                   => 'modifier_strings',
 			'ucwords'                   => 'modifier_strings',
 			'wptexturize'               => 'modifier_strings',
-			'format'                    => 'modifier_format',
+			'format'                    => 'modifier_format', /** @see modifier_format */
 		);
 
 		$modifiers = explode( ',', $modifier );

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -588,20 +588,6 @@ class GravityView_Merge_Tags {
 	}
 
 	/**
-	 * Returns a merge tag modifier parsed into an array with escaped colons replaced by |COLON|.
-	 *
-	 * @since TODO
-	 *
-	 * @param string $modifier
-	 *
-	 * @return false|string[]
-	 */
-	private static function parse_merge_tag_modifier( $modifier ) {
-		// Expand all modifiers, skipping escaped colons. str_replace() works better than preg_split( "/(?<!\\):/" ).
-		return explode( ':', str_replace( '\:', '|COLON|', $modifier ) );
-	}
-
-	/**
 	 * Formats merge tag value using Merge Tags using GVCommon::format_date()
 	 *
 	 * @todo  This is no longer needed since Gravity Forms 2.5 as it supports modifiers, but should be reviewed before removal.
@@ -617,7 +603,7 @@ class GravityView_Merge_Tags {
 	 * @return int|string If timestamp requested, timestamp int. Otherwise, string output.
 	 */
 	public static function format_date( $date_or_time_string = '', $modifier = '' ) {
-		$parsed_modifier = self::parse_merge_tag_modifier( $modifier );
+		$parsed_modifier = explode( ':', $modifier );
 
 		$atts = [
 			'format'    => self::get_format_merge_tag_modifier_value( $modifier, false ),

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * Fixed: When searching a View, the searched time zone would not appear as selected in the Search Bar.
 * Fixed: Fields added to the View could not be configured and would disappear after saving the View when Multiple Forms was enabled.
 * Fixed: Fatal error on the Edit Entry screen when Multiple Forms is enabled.
+* Fixed: The ``:format` merge tag modifier on the Time field returned a UTC-adjusted time value.
 
 = 2.26 on August 8, 2024 =
 


### PR DESCRIPTION
This fixes #2102 and supports various [time format characters](https://www.php.net/manual/en/datetime.format.php), including escaped values and colons such as `\a\t\ H\:i\:s` ([per our guide](https://docs.gravitykit.com/article/331-date-created-merge-tag)).

💾 [Build file](https://www.dropbox.com/scl/fi/mokngjdlvsm116ygdcpb6/gravityview-2.26-07edb8b83.zip?rlkey=jp8uodmb3cqyc5oisyc27aw1i&dl=1) (07edb8b83).