### PR TITLE
Release 2.27

### DIFF
--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -2219,7 +2219,7 @@
 		placeField: function ( $field, $addButton, $anchor, add_before_anchor = false ) {
 			const vcfg = viewConfiguration;
 			const $newField = $field.clone().hide();
-			const templateId = $addButton.attr( 'data-templateid' );
+			const templateId = $addButton.attr( 'data-templateid' ) ?? $addButton.parents( '.gv-section' ).find( '.view-template-select select' ).val();
 
 			const data = {
 				action: 'gv_field_options',

--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.26
+ * Version:             2.27
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
  * Text Domain:         gk-gravityview
@@ -27,7 +27,7 @@ if ( ! GravityKit\GravityView\Foundation\should_load( __FILE__ ) ) {
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.26' );
+define( 'GV_PLUGIN_VERSION', '2.27' );
 
 /**
  * Full path to the GravityView file

--- a/includes/class-admin-views.php
+++ b/includes/class-admin-views.php
@@ -1392,7 +1392,7 @@ HTML;
 		 *
 		 * @filter `gk/gravityview/view/configuration/multiple-entries/initialize-with-all-form-fields`
 		 *
-		 * @since TODO
+		 * @since 2.27
 		 *
 		 * @param bool $show_all_fields Whether to include all form fields (true) or only the fields displayed in the Gravity Forms Entries table (false). Default: `false`.
 		 * @param int  $form_id         The current form ID.

--- a/includes/class-admin-views.php
+++ b/includes/class-admin-views.php
@@ -1082,7 +1082,7 @@ HTML;
 
 					<?php foreach ( $areas as $area ) : ?>
 
-						<div class="gv-droppable-area" data-areaid="<?php echo esc_attr( $zone . '_' . $area['areaid'] ); ?>" data-context="<?php echo esc_attr( $zone ); ?>">
+						<div class="gv-droppable-area" data-areaid="<?php echo esc_attr( $zone . '_' . $area['areaid'] ); ?>" data-context="<?php echo esc_attr( $zone ); ?>" data-templateid="<?php echo esc_attr( $template_id ); ?>">
 							<p class="gv-droppable-area-title"
 							<?php
 							if ( 'widget' === $type && empty( $area['subtitle'] ) ) {

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -296,6 +296,25 @@ class GravityView_Welcome {
 				 *  - If 4.28, include to 4.26.
 				 */
 				?>
+				<h3>2.27 on August 13, 2024</h3>
+
+				<p>This update resolves several issues related to the Multiple Forms extension, fixes the recently introduced <code>:format</code> merge tag modifier to return the Time field value in the local timezone, and adds a new filter to control which fields are added by default when creating a new View.</p>
+
+				<h4>🐛 Fixed</h4>
+
+				<ul>
+					<li>Time zone selection in the Search Bar did not persist after searching a View, causing it to reset upon page refresh.</li>
+					<li>Fields added to the View could not be configured and would disappear after saving the View when Multiple Forms was enabled.</li>
+					<li>Fatal error occurred on the Edit Entry screen when Multiple Forms was enabled.</li>
+					<li>The <code>:format</code> merge tag modifier on the Time field returned a UTC-adjusted time value.</li>
+				</ul>
+
+				<h4>💻 Developer Updates</h4>
+
+				<ul>
+					<li>Added: <code>gk/gravityview/view/configuration/multiple-entries/initialize-with-all-form-fields</code> filter that, when set to <code>true</code>, initializes the Multiple Entries layout with all form fields when creating a new View. The default is <code>false</code>, which populates the View with only the fields configured in the Gravity Forms Entries table.</li>
+				</ul>
+
 				<h3>2.26 on August 8, 2024</h3>
 
 				<p>This update resolves various issues, including compatibility with Yoast SEO, improves performance through enhanced View entries caching, and adds new functionality.</p>
@@ -368,38 +387,6 @@ class GravityView_Welcome {
 
 				<ul>
 					<li>Removed the <code>gk/gravityview/field/is-read/print-script</code> filter in favor of the improved functionality that marks entries as "Read".</li>
-				</ul>
-
-				<h3>2.24 on May 28, 2024</h3>
-
-				<p>This release introduces the ability to use different view types for Multiple Entries and Single Entry layouts, adds a new View field to display an entry's read status, and fixes issues with the File Upload field, product search, and merge tag processing in entry-based notifications. <a href="https://www.gravitykit.com/announcing-gravityview-2-24/">Read the announcement</a> for more details.</p>
-
-				<h4>🚀 Added</h4>
-
-				<ul>
-					<li>Ability to select different View types for Multiple Entries and Single Entry layouts. <a href="https://www.gravitykit.com/announcing-gravityview-2-24">Learn all about the new View type switcher!</a></li>
-					<li>"Read Status" field to display whether an entry has been read or not.</li>
-					<ul>
-						<li>Customize the labels for "Read" and "Unread" statuses.</li>
-						<li>Sort a View by "Read Status".</li>
-					</ul>
-				</ul>
-
-				<h4>🐛 Fixed</h4>
-
-				<ul>
-					<li>File Upload field values not rendering in the View if filenames have non-Latin characters.</li>
-					<li>Product search now returns correct results when using all search input types in the search bar.</li>
-					<li>View's Export Link widget would not respect date range search filters.</li>
-					<li>Removed the unsupported "date" input type for the Date Entry field under the Search Bar widget settings.</li>
-					<li>Merge tags in GravityView notifications are now properly processed for fields dynamically populated by Gravity Wiz's Populate Anything add-on.</li>
-				</ul>
-
-				<h4>💻 Developer Updates</h4>
-
-				<ul>
-					<li>Added <code>gk/gravityview/field/is-read/print-script</code> filter to modify whether to print the script in the frontend that marks an entry as "Read".</li>
-					<li>Added <code>gk/gravityview/field/is-read/label</code> filter to change the "Is Read" field's "Read" and "Unread" labels.</li>
 				</ul>
 
 				<p style="text-align: center;">

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -312,7 +312,7 @@ class GravityView_Welcome {
 				<h4>💻 Developer Updates</h4>
 
 				<ul>
-					<li>Added: <code>gk/gravityview/view/configuration/multiple-entries/initialize-with-all-form-fields</code> filter that, when set to <code>true</code>, initializes the Multiple Entries layout with all form fields when creating a new View. The default is <code>false</code>, which populates the View with only the fields configured in the Gravity Forms Entries table.</li>
+					<li>Added <code>gk/gravityview/view/configuration/multiple-entries/initialize-with-all-form-fields</code> filter that, when set to <code>true</code>, initializes the Multiple Entries layout with all form fields when creating a new View. The default is <code>false</code>, which populates the View with only the fields configured in the Gravity Forms Entries table.</li>
 				</ul>
 
 				<h3>2.26 on August 8, 2024</h3>
@@ -352,8 +352,8 @@ class GravityView_Welcome {
 				<h4>💻 Developer Updates</h4>
 
 				<ul>
-					<li>Added: <code>gk/gravityview/feature/upgrade/disabled</code> filter to disable the functionality placeholders. Return <code>true</code> to disable the placeholders.</li>
-					<li>Added: <code>gk/gravityview/metabox/content/before</code> and <code>gk/gravityview/metabox/content/after</code> actions, triggered before and after the View metabox is rendered.</li>
+					<li>Added <code>gk/gravityview/feature/upgrade/disabled</code> filter to disable the functionality placeholders. Return <code>true</code> to disable the placeholders.</li>
+					<li>Added <code>gk/gravityview/metabox/content/before</code> and <code>gk/gravityview/metabox/content/after</code> actions, triggered before and after the View metabox is rendered.</li>
 				</ul>
 
 				<h3>2.25 on June 5, 2024</h3>

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -95,15 +95,10 @@ class GravityView_Merge_Tags {
 
 		// matching regex => the value is the method to call to replace the value.
 		$gv_modifiers = array(
-			'maxwords:(\d+)'            => 'modifier_maxwords',
-			/** @see modifier_maxwords */
-							'timestamp' => 'modifier_timestamp',
-			/** @see modifier_timestamp */
-							'explode'   => 'modifier_explode',
-			/** @see modifier_explode */
-
-							/** @see modifier_strings */
-							'urlencode' => 'modifier_strings',
+			'maxwords:(\d+)'            => 'modifier_maxwords', /** @see modifier_maxwords */
+			'timestamp'                 => 'modifier_timestamp', /** @see modifier_timestamp */
+			'explode'                   => 'modifier_explode', /** @see modifier_explode */
+			'urlencode'                 => 'modifier_strings', /** @see modifier_strings */
 			'wpautop'                   => 'modifier_strings',
 			'esc_html'                  => 'modifier_strings',
 			'sanitize_html_class'       => 'modifier_strings',
@@ -113,7 +108,7 @@ class GravityView_Merge_Tags {
 			'ucfirst'                   => 'modifier_strings',
 			'ucwords'                   => 'modifier_strings',
 			'wptexturize'               => 'modifier_strings',
-			'format'                    => 'modifier_format',
+			'format'                    => 'modifier_format', /** @see modifier_format */
 		);
 
 		$modifiers = explode( ',', $modifier );
@@ -181,7 +176,17 @@ class GravityView_Merge_Tags {
 	 * @return string
 	 */
 	private static function modifier_format( $raw_value, $matches, $value, $field, $modifier ) {
-		if ( ( $field instanceof GF_Field_Date || $field instanceof GF_Field_Time ) && $modifier ) {
+		$format = self::get_format_merge_tag_modifier_value( $modifier );
+
+		if ( ! $format ) {
+			return $raw_value;
+		}
+
+		if ( $field instanceof GF_Field_Time ) {
+			return ( new DateTime( $raw_value ) )->format( $format ); // GF's Time field always uses local time.
+		}
+
+		if ( $field instanceof GF_Field_Date ) {
 			return self::format_date( $raw_value, $modifier );
 		}
 
@@ -578,63 +583,51 @@ class GravityView_Merge_Tags {
 	}
 
 	/**
-	 * Format Merge Tags using GVCommon::format_date()
+	 * Formats merge tag value using Merge Tags using GVCommon::format_date()
 	 *
-	 * @uses GVCommon::format_date()
-	 *
-	 * @see https://docs.gravitykit.com/article/331-date-created-merge-tag for documentation
-	 * @todo Once Gravity Forms 2.5 becomes the minimum requirement, this is no longer needed.
-	 *
-	 * @param string $date_created The Gravity Forms date created format
-	 * @param string $property Any modifiers for the merge tag (`human`, `format:m/d/Y`)
-	 *
-	 * @return int|string If timestamp requested, timestamp int. Otherwise, string output.
-	 */
-	public static function format_date( $date_created = '', $property = '' ) {
-
-		// Expand all modifiers, skipping escaped colons. str_replace worked better than preg_split( "/(?<!\\):/" )
-		$exploded = explode( ':', str_replace( '\:', '|COLON|', $property ) );
-
-		$atts = array(
-			'format'    => self::get_format_from_modifiers( $exploded, false ),
-			'human'     => in_array( 'human', $exploded ), // {date_created:human}
-			'diff'      => in_array( 'diff', $exploded ), // {date_created:diff}
-			'raw'       => in_array( 'raw', $exploded ), // {date_created:raw}
-			'timestamp' => in_array( 'timestamp', $exploded ), // {date_created:timestamp}
-			'time'      => in_array( 'time', $exploded ),  // {date_created:time}
-		);
-
-		$formatted_date = GVCommon::format_date( $date_created, $atts );
-
-		return $formatted_date;
-	}
-
-	/**
-	 * If there is a `:format` modifier in a merge tag, grab the formatting
-	 *
-	 * The `:format` modifier should always have the format follow it; it's the next item in the array
-	 * In `foo:format:bar`, "bar" will be the returned format
+	 * @todo  This is no longer needed since Gravity Forms 2.5 as it supports modifiers, but should be reviewed before removal.
 	 *
 	 * @since 1.16
 	 *
-	 * @param array  $exploded Array of modifiers with a possible `format` value
-	 * @param string $backup The backup value to use, if not found
+	 * @see   https://docs.gravitykit.com/article/331-date-created-merge-tag for documentation
+	 * @uses  GVCommon::format_date()
+	 *
+	 * @param string $date_or_time_string The Gravity Forms date or time string.
+	 * @param string $modifier            Merge tag modifier (`human`, `format:m/d/Y`)
+	 *
+	 * @return int|string If timestamp requested, timestamp int. Otherwise, string output.
+	 */
+	public static function format_date( $date_or_time_string = '', $modifier = '' ) {
+		$parsed_modifier = explode( ':', $modifier );
+
+		$atts = [
+			'format'    => self::get_format_merge_tag_modifier_value( $modifier, false ),
+			'human'     => in_array( 'human', $parsed_modifier ), // {date_created:human}
+			'diff'      => in_array( 'diff', $parsed_modifier ), // {date_created:diff}
+			'raw'       => in_array( 'raw', $parsed_modifier ), // {date_created:raw}
+			'timestamp' => in_array( 'timestamp', $parsed_modifier ), // {date_created:timestamp}
+			'time'      => in_array( 'time', $parsed_modifier ),  // {date_created:time}
+		];
+
+		return GVCommon::format_date( $date_or_time_string, $atts );
+	}
+
+	/**
+	 * Returns the `format:` merge tag modifier value.
+	 * This handles cases such as "foo:format:m/d/Y", "format:m/d/Y", "format:m/d/Y\ \a\t\ H\:i\:s".
+	 *
+	 * @since 1.16
+	 * @since TODO Renamed and refactored to use regex and instead of working with an array.
+	 *
+	 * @param string $modifier Merge tag modifier.
+	 * @param mixed  $backup   The backup value to use, if format not found.
 	 *
 	 * @return string If format is found, the passed format. Otherwise, the backup.
 	 */
-	private static function get_format_from_modifiers( $exploded, $backup = '' ) {
+	private static function get_format_merge_tag_modifier_value( $modifier, $backup = '' ) {
+		preg_match( '/(?:^|:)format:(.*)/', $modifier, $match );
 
-		$return = $backup;
-
-		$format_key_index = array_search( 'format', $exploded );
-
-		// If there's a "format:[php date format string]" date format, grab it
-		if ( false !== $format_key_index && isset( $exploded[ $format_key_index + 1 ] ) ) {
-			// Return escaped colons placeholder
-			$return = str_replace( '|COLON|', ':', implode( ':', array_slice( $exploded, $format_key_index + 1 ) ) );
-		}
-
-		return $return;
+		return isset( $match[1] ) ? str_replace( '\:', ':', $match[1] ) : $backup;
 	}
 
 	/**

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -617,7 +617,7 @@ class GravityView_Merge_Tags {
 	 * This handles cases such as "foo:format:m/d/Y", "format:m/d/Y", "format:m/d/Y\ \a\t\ H\:i\:s".
 	 *
 	 * @since 1.16
-	 * @since TODO Renamed and refactored to use regex and instead of working with an array.
+	 * @since 2.27 Renamed and refactored to use regex and instead of working with an array.
 	 *
 	 * @param string $modifier Merge tag modifier.
 	 * @param mixed  $backup   The backup value to use, if format not found.

--- a/includes/fields/class-gravityview-field-approval.php
+++ b/includes/fields/class-gravityview-field-approval.php
@@ -1,5 +1,7 @@
 <?php
 
+use GV\Multi_Entry;
+
 /**
  * Add custom options for address fields
  *
@@ -353,17 +355,19 @@ class GravityView_Field_Entry_Approval extends GravityView_Field {
 
 			$unique_id = crc32( 'is_approved' );
 
-			$entry  = gravityview()->request->is_edit_entry( $form['id'] );
+			$approval_value = GravityView_Entry_Approval_Status::UNAPPROVED;
 
-			$value = '';
+			$entry = gravityview()->request->is_entry();
 
 			if ( $entry ) {
+				$entry = $entry instanceof Multi_Entry ? reset( $entry->entries ) : $entry;
+
 				$entry = $entry->as_entry();
 
-				$value = $entry['is_approved'] ? (int) $entry['is_approved'] : GravityView_Entry_Approval_Status::UNAPPROVED;
+				$approval_value = $entry['is_approved'] ?? $approval_value;
 			}
 
-			$value = $_POST[ "input_{$unique_id}" ] ?? $value;
+			$approval_value = $_POST[ "input_{$unique_id}" ] ?? $approval_value;
 
 			$field_data = array(
 				'id'           => $unique_id,
@@ -383,7 +387,7 @@ class GravityView_Field_Entry_Approval extends GravityView_Field {
 						'value' => GravityView_Entry_Approval_Status::UNAPPROVED,
 					),
 				),
-				'defaultValue' => (int) $value,
+				'defaultValue' => (int) $approval_value,
 				'cssClass'     => $edit_field['custom_class'],
 			);
 

--- a/includes/fields/class-gravityview-field-approval.php
+++ b/includes/fields/class-gravityview-field-approval.php
@@ -336,9 +336,6 @@ class GravityView_Field_Entry_Approval extends GravityView_Field {
 		$new_fields = array();
 		$i          = 0;
 
-		$entry  = gravityview()->request->is_edit_entry( $form['id'] );
-		$_entry = $entry->as_entry();
-
 		foreach ( (array) $edit_fields as $id => $edit_field ) {
 			if ( 'entry_approval' !== $edit_field['id'] ) {
 				if ( isset( $fields[ $i ] ) ) {
@@ -356,7 +353,16 @@ class GravityView_Field_Entry_Approval extends GravityView_Field {
 
 			$unique_id = crc32( 'is_approved' );
 
-			$value = ( $_entry['is_approved'] ? (int) $_entry['is_approved'] : GravityView_Entry_Approval_Status::UNAPPROVED );
+			$entry  = gravityview()->request->is_edit_entry( $form['id'] );
+
+			$value = '';
+
+			if ( $entry ) {
+				$entry = $entry->as_entry();
+
+				$value = $entry['is_approved'] ? (int) $entry['is_approved'] : GravityView_Entry_Approval_Status::UNAPPROVED;
+			}
+
 			$value = $_POST[ "input_{$unique_id}" ] ?? $value;
 
 			$field_data = array(

--- a/includes/plugin-and-theme-hooks/class-gravityview-object-placeholder.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-object-placeholder.php
@@ -231,6 +231,9 @@ final class GravityView_Object_Placeholder {
 		}
 
 		$attributes = [ 'data-text-domain' => $this->text_domain ];
+
+		$buy_now_link = $this->get_buy_now_link_with_utms();
+
 		if ( self::STATUS_INACTIVE === $this->get_status() ) {
 			$plugin          = $this->get_plugin();
 			$plugin_basename = $plugin['path'] ?? '';
@@ -243,20 +246,19 @@ final class GravityView_Object_Placeholder {
 			$caps                      = 'install_plugins';
 			$attributes['data-action'] = 'install';
 			$button_text               = __( 'Install & Activate', 'gk-gravityview' );
-			$button_href               = $this->buy_now_link;
+			$button_href               = $buy_now_link;
 		} else {
 			$caps        = 'read';
 			$button_text = __( 'Buy Now', 'gk-gravityview' );
-			$button_href = $this->buy_now_link;
+			$button_href = $buy_now_link;
 		}
 
-		$params = compact( 'caps', 'button_href', 'button_text', 'attributes' );
+		$params = compact( 'caps', 'button_href', 'button_text', 'attributes', 'buy_now_link' );
 		$params = array_merge( $params, [
 			'type'         => (string) $this->type,
 			'icon'         => (string) $this->icon,
 			'title'        => (string) $this->title,
 			'description'  => (string) $this->description,
-			'buy_now_link' => (string) $this->buy_now_link,
 		] );
 
 		// Render the template in a scoped function.
@@ -264,5 +266,21 @@ final class GravityView_Object_Placeholder {
 			extract( $params );
 			require GRAVITYVIEW_DIR . 'includes/admin/metaboxes/views/placeholder.php';
 		} )();
+	}
+
+	/**
+	 * Returns the Buy Now link with UTM parameters added.
+	 *
+	 * @since TODO
+	 *
+	 * @return string The buy now link.
+	 */
+	private function get_buy_now_link_with_utms(): string {
+		return add_query_arg( [
+			'utm_source'   => 'plugin',
+			'utm_medium'   => 'buy_now',
+			'utm_campaign' => 'placeholders',
+			'utm_term'     => $this->text_domain,
+		], $this->buy_now_link );
 	}
 }

--- a/includes/plugin-and-theme-hooks/class-gravityview-object-placeholder.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-object-placeholder.php
@@ -271,7 +271,7 @@ final class GravityView_Object_Placeholder {
 	/**
 	 * Returns the Buy Now link with UTM parameters added.
 	 *
-	 * @since TODO
+	 * @since 2.27
 	 *
 	 * @return string The buy now link.
 	 */

--- a/includes/widgets/search-widget/templates/search-field-select.php
+++ b/includes/widgets/search-widget/templates/search-field-select.php
@@ -46,7 +46,7 @@ $default_option = apply_filters( 'gravityview/extension/search/select_default', 
 				<?php if ( is_array( $choice['value'] ) ) { ?>
 					<optgroup label="<?php echo esc_attr( $choice['text'] ); ?>">
 						<?php foreach ( $choice['value'] as $subchoice ) : ?>
-							<option value="<?php echo esc_attr( $subchoice['value'] ); ?>"><?php echo esc_html( $subchoice['text'] ); ?></option>
+							<option value="<?php echo esc_attr( $subchoice['value'] ); ?>" <?php gv_selected( esc_attr( $subchoice['value'] ), esc_attr( $search_field['value'] ), true ); ?>><?php echo esc_html( $subchoice['text'] ); ?></option>
 						<?php endforeach; ?>
 					</optgroup>
 				<?php } else { ?>

--- a/readme.txt
+++ b/readme.txt
@@ -21,16 +21,18 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
-= develop =
+= 2.27 on August 13, 2024 =
 
-* Fixed: When searching a View, the searched time zone would not appear as selected in the Search Bar.
-* Fixed: Fields added to the View could not be configured and would disappear after saving the View when Multiple Forms was enabled.
-* Fixed: Fatal error on the Edit Entry screen when Multiple Forms is enabled.
-* Fixed: The ``:format` merge tag modifier on the Time field returned a UTC-adjusted time value.
+This update resolves several issues related to the Multiple Forms extension, fixes the recently introduced `:format` merge tag modifier to return the Time field value in the local timezone, and adds a new filter to control which fields are added by default when creating a new View.
 
-__Developer Updates:__
+#### 🐛 Fixed
+* Time zone selection in the Search Bar did not persist after searching a View, causing it to reset upon page refresh.
+* Fields added to the View could not be configured and would disappear after saving the View when Multiple Forms was enabled.
+* Fatal error occurred on the Edit Entry screen when Multiple Forms was enabled.
+* The `:format` merge tag modifier on the Time field returned a UTC-adjusted time value.
 
-* Added: `gk/gravityview/view/configuration/multiple-entries/initialize-with-all-form-fields` filter that, when set to `true`, initializes the Multiple Entries layout with all form fields when creating a new View. The default is `false`, which populates the View with only the fields configured in the Gravity Forms Entries table.
+#### 💻 Developer Updates
+* Added `gk/gravityview/view/configuration/multiple-entries/initialize-with-all-form-fields` filter that, when set to `true`, initializes the Multiple Entries layout with all form fields when creating a new View. The default is `false`, which populates the View with only the fields configured in the Gravity Forms Entries table.
 
 = 2.26 on August 8, 2024 =
 
@@ -55,8 +57,8 @@ This update resolves various issues, including compatibility with Yoast SEO, imp
 * [Foundation](https://www.gravitykit.com/foundation/) and [TrustedLogin](https://www.trustedlogin.com/) to versions 1.2.17 and 1.8.0, respectively.
 
 #### 💻 Developer Updates
-* Added: `gk/gravityview/feature/upgrade/disabled` filter to disable the functionality placeholders. Return `true` to disable the placeholders.
-* Added: `gk/gravityview/metabox/content/before` and `gk/gravityview/metabox/content/after` actions, triggered before and after the View metabox is rendered.
+* Added `gk/gravityview/feature/upgrade/disabled` filter to disable the functionality placeholders. Return `true` to disable the placeholders.
+* Added `gk/gravityview/metabox/content/before` and `gk/gravityview/metabox/content/after` actions, triggered before and after the View metabox is rendered.
 
 = 2.25 on June 5, 2024 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * Fixed: When searching a View, the searched time zone would not appear as selected in the Search Bar.
 * Fixed: Fields added to the View could not be configured and would disappear after saving the View when Multiple Forms was enabled.
 * Fixed: Fatal error on the Edit Entry screen when Multiple Forms is enabled.
+* Fixed: The ``:format` merge tag modifier on the Time field returned a UTC-adjusted time value.
 
 = 2.26 on August 8, 2024 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,8 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 * Fixed: When searching a View, the searched time zone would not appear as selected in the Search Bar.
 * Fixed: Fields added to the View could not be configured and would disappear after saving the View when Multiple Forms was enabled.
+* Fixed: Fatal error on the Edit Entry screen when Multiple Forms is enabled.
+
 = 2.26 on August 8, 2024 =
 
 This update resolves various issues, including compatibility with Yoast SEO, improves performance through enhanced View entries caching, and adds new functionality.

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * Fixed: Fatal error on the Edit Entry screen when Multiple Forms is enabled.
 * Fixed: The ``:format` merge tag modifier on the Time field returned a UTC-adjusted time value.
 
+__Developer Updates:__
+
+* Added: `gk/gravityview/view/configuration/multiple-entries/initialize-with-all-form-fields` filter that, when set to `true`, initializes the Multiple Entries layout with all form fields when creating a new View. The default is `false`, which populates the View with only the fields configured in the Gravity Forms Entries table.
+
 = 2.26 on August 8, 2024 =
 
 This update resolves various issues, including compatibility with Yoast SEO, improves performance through enhanced View entries caching, and adds new functionality.

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+* Fixed: When searching a View, the searched time zone would not appear as selected in the Search Bar.
+
 = 2.26 on August 8, 2024 =
 
 This update resolves various issues, including compatibility with Yoast SEO, improves performance through enhanced View entries caching, and adds new functionality.

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 = develop =
 
 * Fixed: When searching a View, the searched time zone would not appear as selected in the Search Bar.
-
+* Fixed: Fields added to the View could not be configured and would disappear after saving the View when Multiple Forms was enabled.
 = 2.26 on August 8, 2024 =
 
 This update resolves various issues, including compatibility with Yoast SEO, improves performance through enhanced View entries caching, and adds new functionality.


### PR DESCRIPTION
This update resolves several issues related to the Multiple Forms extension, fixes the recently introduced `:format` merge tag modifier to return the Time field value in the local timezone, and adds a new filter to control which fields are added by default when creating a new View.

#### 🐛 Fixed
* Time zone selection in the Search Bar did not persist after searching a View, causing it to reset upon page refresh.
* Fields added to the View could not be configured and would disappear after saving the View when Multiple Forms was enabled.
* Fatal error occurred on the Edit Entry screen when Multiple Forms was enabled.
* The `:format` merge tag modifier on the Time field returned a UTC-adjusted time value.

#### 💻 Developer Updates
* Added `gk/gravityview/view/configuration/multiple-entries/initialize-with-all-form-fields` filter that, when set to `true`, initializes the Multiple Entries layout with all form fields when creating a new View. The default is `false`, which populates the View with only the fields configured in the Gravity Forms Entries table.
