### PR TITLE
Release 2.27.1

### DIFF
--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -2219,7 +2219,7 @@
 		placeField: function ( $field, $addButton, $anchor, add_before_anchor = false ) {
 			const vcfg = viewConfiguration;
 			const $newField = $field.clone().hide();
-			const templateId = $addButton.attr( 'data-templateid' ) ?? $addButton.parents( '.gv-section' ).find( '.view-template-select select' ).val();
+			const templateId = $addButton.attr( 'data-templateid' ) ?? $addButton.parents( '.gv-section' ).find( '.view-template-select select' ).val() ?? $( "#gravityview_directory_template" ).val();
 
 			const data = {
 				action: 'gv_field_options',

--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.27
+ * Version:             2.27.1
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
  * Text Domain:         gk-gravityview
@@ -27,7 +27,7 @@ if ( ! GravityKit\GravityView\Foundation\should_load( __FILE__ ) ) {
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.27' );
+define( 'GV_PLUGIN_VERSION', '2.27.1' );
 
 /**
  * Full path to the GravityView file

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -296,6 +296,16 @@ class GravityView_Welcome {
 				 *  - If 4.28, include to 4.26.
 				 */
 				?>
+				<h3>2.27.1 on August 14, 2024</h3>
+
+				<p>This release fixes an issue with adding fields in the View editor's Edit Entry layout when the Multiple Forms extension is enabled.</p>
+
+				<h4>🐛 Fixed</h4>
+
+				<ul>
+					<li>Fields added to the Edit Entry layout in the View editor could not be configured and would disappear after saving the View when Multiple Forms was enabled.</li>
+				</ul>
+
 				<h3>2.27 on August 13, 2024</h3>
 
 				<p>This update resolves several issues related to the Multiple Forms extension, fixes the recently introduced <code>:format</code> merge tag modifier to return the Time field value in the local timezone, and adds a new filter to control which fields are added by default when creating a new View.</p>

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,13 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= 2.27.1 on August 14, 2024 =
+
+This release fixes an issue with adding fields in the View editor's Edit Entry layout when the Multiple Forms extension is enabled.
+
+#### 🐛 Fixed
+* Fields added to the Edit Entry layout in the View editor could not be configured and would disappear after saving the View when Multiple Forms was enabled.
+
 = 2.27 on August 13, 2024 =
 
 This update resolves several issues related to the Multiple Forms extension, fixes the recently introduced `:format` merge tag modifier to return the Time field value in the local timezone, and adds a new filter to control which fields are added by default when creating a new View.


### PR DESCRIPTION
This release fixes an issue with adding fields in the View editor's Edit Entry layout when the Multiple Forms extension is enabled.

#### 🐛 Fixed
* Fields added to the Edit Entry layout in the View editor could not be configured and would disappear after saving the View when Multiple Forms was enabled.


💾 [Build file](https://www.dropbox.com/scl/fi/6d53n1y41ew4s0okmf2o2/gravityview-2.27.1-2792e8566.zip?rlkey=zxgce968haa7ltomdgy1pkujf&dl=1) (2792e8566).