### PR TITLE
Add human modifier for date and time fields

### DIFF
--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -1206,7 +1206,9 @@ class GVCommon {
 		// If we're using time diff, we want to have a different default format
 		if ( empty( $format ) ) {
 			/* translators: %s: relative time from now, used for generic date comparisons. "1 day ago", or "20 seconds ago" */
-			$format = $is_diff ? esc_html__( '%s ago', 'gk-gravityview' ) : get_option( 'date_format' );
+			$is_past = ( $atts['diff'] < 0 );
+			$time_diff = $is_past ? esc_html__( '%s ago', 'gk-gravityview' ) : esc_html__( '%s from now', 'gk-gravityview' );
+			$format = $is_diff ? $time_diff : get_option( 'date_format' );
 		}
 
 		// If raw was specified, don't modify the stored value

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -1202,15 +1202,15 @@ class GVCommon {
 		$is_raw       = ! empty( $atts['raw'] );
 		$is_timestamp = ! empty( $atts['timestamp'] );
 		$include_time = ! empty( $atts['time'] );
-		$time_diff = strtotime( $date_string ) - current_time( 'timestamp' );
+		$time_diff    = strtotime( $date_string ) - current_time( 'timestamp' );
 
 
 		// If we're using time diff, we want to have a different default format
 		if ( empty( $format ) ) {
 			/* translators: %s: relative time from now, used for generic date comparisons. "1 day ago", or "20 seconds ago" */
-			$is_past = ( $time_diff < 0 );
+			$is_past    = ( $time_diff < 0 );
 			$human_diff = $is_past ? esc_html__( '%s ago', 'gk-gravityview' ) : esc_html__( '%s from now', 'gk-gravityview' );
-			$format = $is_diff ? $human_diff : get_option( 'date_format' );
+			$format     = $is_diff ? $human_diff : get_option( 'date_format' );
 		}
 
 		// If raw was specified, don't modify the stored value
@@ -1219,7 +1219,7 @@ class GVCommon {
 		} elseif ( $is_timestamp ) {
 			$formatted_date = $date_local_timestamp;
 		} elseif ( $is_diff ) {
-			$formatted_date = sprintf( $format, human_time_diff( $date_gmt_time, current_time('timestamp') ) );
+			$formatted_date = sprintf( $format, human_time_diff( $date_gmt_time, current_time( 'timestamp' ) ) );
 		} else {
 			$formatted_date = GFCommon::format_date( $date_string, $is_human, $format, $include_time );
 		}

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -1219,7 +1219,7 @@ class GVCommon {
 		} elseif ( $is_timestamp ) {
 			$formatted_date = $date_local_timestamp;
 		} elseif ( $is_diff ) {
-			$formatted_date = sprintf( $format, human_time_diff( $date_gmt_time ) );
+			$formatted_date = sprintf( $format, human_time_diff( $date_gmt_time, current_time('timestamp') ) );
 		} else {
 			$formatted_date = GFCommon::format_date( $date_string, $is_human, $format, $include_time );
 		}

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -1202,13 +1202,15 @@ class GVCommon {
 		$is_raw       = ! empty( $atts['raw'] );
 		$is_timestamp = ! empty( $atts['timestamp'] );
 		$include_time = ! empty( $atts['time'] );
+		$time_diff = strtotime( $date_string ) - current_time( 'timestamp' );
+
 
 		// If we're using time diff, we want to have a different default format
 		if ( empty( $format ) ) {
 			/* translators: %s: relative time from now, used for generic date comparisons. "1 day ago", or "20 seconds ago" */
-			$is_past = ( $atts['diff'] < 0 );
-			$time_diff = $is_past ? esc_html__( '%s ago', 'gk-gravityview' ) : esc_html__( '%s from now', 'gk-gravityview' );
-			$format = $is_diff ? $time_diff : get_option( 'date_format' );
+			$is_past = ( $time_diff < 0 );
+			$human_diff = $is_past ? esc_html__( '%s ago', 'gk-gravityview' ) : esc_html__( '%s from now', 'gk-gravityview' );
+			$format = $is_diff ? $human_diff : get_option( 'date_format' );
 		}
 
 		// If raw was specified, don't modify the stored value

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -185,7 +185,7 @@ class GravityView_Merge_Tags {
 		}
 
 		$current_time = current_time( 'timestamp' );
-		$time_diff    = human_time_diff( strtotime( $raw_value ), $current_time );
+		$time_diff = strtotime( $raw_value ) - $current_time;
 		$args         = array(
 			'human' => true,
 			'diff'  => $time_diff,

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -184,10 +184,10 @@ class GravityView_Merge_Tags {
 			return $raw_value;
 		}
 
-		$args         = array(
+		$args = [
 			'human' => true,
 			'diff'  => true,
-		);
+		];
 
 		if ( $field instanceof GF_Field_Time ) {
 			$args['time'] = true;

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -184,11 +184,9 @@ class GravityView_Merge_Tags {
 			return $raw_value;
 		}
 
-		$current_time = current_time( 'timestamp' );
-		$time_diff = strtotime( $raw_value ) - $current_time;
 		$args         = array(
 			'human' => true,
-			'diff'  => $time_diff,
+			'diff'  => true,
 		);
 
 		if ( $field instanceof GF_Field_Time ) {

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -109,6 +109,7 @@ class GravityView_Merge_Tags {
 			'ucwords'                   => 'modifier_strings',
 			'wptexturize'               => 'modifier_strings',
 			'format'                    => 'modifier_format', /** @see modifier_format */
+			'human'						=> 'modifier_human', /** @see modifier_human */
 		);
 
 		$modifiers = explode( ',', $modifier );
@@ -160,6 +161,41 @@ class GravityView_Merge_Tags {
 		$return = apply_filters( 'gravityview/merge_tags/modifiers/value', $return, $raw_value, $value, $merge_tag, $modifier, $field );
 
 		return $return;
+	}
+
+	/**
+	 * Converts date and time values to the human format modifier.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $raw_value The raw value to modify.
+	 * @param array  $matches   Array of regex matches.
+	 * @param string $value     The original value.
+	 * @param array  $field     The field object.
+	 * @param string $modifier  The modifier string.
+	 *
+	 * @return string
+	 */
+	public static function modifier_human( $raw_value, $matches, $value = '', $field = null, $modifier = '' ) {
+		// Check if the value is a valid date.
+		$timestamp = strtotime( $raw_value );
+
+		if ( false === $timestamp || ( ! $field instanceof GF_Field_Date && ! $field instanceof GF_Field_Time ) ) {
+			return $raw_value;
+		}
+
+		$current_time = current_time( 'timestamp' );
+		$time_diff    = human_time_diff( strtotime( $raw_value ), $current_time );
+		$args         = array(
+			'human' => true,
+			'diff'  => $time_diff,
+		);
+
+		if ( $field instanceof GF_Field_Time ) {
+			$args['time'] = true;
+		}
+
+		return GVCommon::format_date( $raw_value, $args );
 	}
 
 	/**

--- a/includes/fields/class-gravityview-field-date.php
+++ b/includes/fields/class-gravityview-field-date.php
@@ -58,9 +58,8 @@ class GravityView_Field_Date extends GravityView_Field {
 	 * @return string If Date field, run it through GravityView_Merge_Tags::format_date; otherwise, return the original value
 	 */
 	public function apply_format_date_modifiers( $return, $raw_value = '', $value = '', $merge_tag = '', $modifier = '', $field = null ) {
-
 		if ( 'date' === $field->type ) {
-			// If human then don't change anything as it's already been formatted.
+			// If human modifier is used, don't change anything as it's already been formatted.
 			if ( strpos( $modifier, 'human' ) !== false ) {
 				return $return;
 			}

--- a/includes/fields/class-gravityview-field-date.php
+++ b/includes/fields/class-gravityview-field-date.php
@@ -60,6 +60,11 @@ class GravityView_Field_Date extends GravityView_Field {
 	public function apply_format_date_modifiers( $return, $raw_value = '', $value = '', $merge_tag = '', $modifier = '', $field = null ) {
 
 		if ( 'date' === $field->type ) {
+			// If human then don't change anything as it's already been formatted.
+			if ( strpos( $modifier, 'human' ) !== false ) {
+				return $return;
+			}
+
 			$return = GravityView_Merge_Tags::format_date( $raw_value, $modifier );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === GravityView ===
 Tags: gravity forms, directory, gravity forms directory
 Requires at least: 4.7
-Tested up to: 6.6.1
+Tested up to: 6.6.2
 Requires PHP: 7.4.0
 Stable tag: trunk
 Contributors: The GravityKit Team
@@ -23,6 +23,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
+* Added: `:human` merge tag modifier for date fields to display in human-readable format (e.g., `10 minutes ago`, `5 days from now`).
 * Fixed: Clearing search removed all URL query parameters and under some circumstances redirected to the homepage.
 * Fixed: Searching the View added duplicate search parameters to the URL.
 

--- a/tests/unit-tests/GVCommon_Common_Test.php
+++ b/tests/unit-tests/GVCommon_Common_Test.php
@@ -109,12 +109,19 @@ class GVCommon_Test extends GV_UnitTestCase {
 	function test_format_date() {
 
 		$form = $this->factory->form->create_and_get();
+		$current_time = current_time( 'mysql' );
+		$two_days_from_now  = date( 'Y-m-d H:i:s', strtotime( $current_time . ' +2 day' ) );
+		$two_hours_from_now = date( 'h:i a', strtotime( $current_time . ' +2 hour' ) );
 
 		$entry = $this->factory->entry->create_and_get( array(
 			'form_id' => $form['id'],
+			'10' 	  => $two_days_from_now,
+			'11'	  =>$two_hours_from_now
 		) );
 
 		$date_created = \GV\Utils::get( $entry, 'date_created' );
+		$datepicker = \GV\Utils::get( $entry, '10' );
+		$time = \GV\Utils::get( $entry, '11' );
 
 		/**
 		 * adjusting date to local configured Time Zone
@@ -122,6 +129,12 @@ class GVCommon_Test extends GV_UnitTestCase {
 		 */
 		$entry_gmt_time   = mysql2date( 'G', $date_created );
 		$entry_local_time = GFCommon::get_local_timestamp( $entry_gmt_time );
+
+		$datepicker_gmt_time   = mysql2date( 'G', $datepicker );
+		$datepicker_local_time = GFCommon::get_local_timestamp( $datepicker_gmt_time );
+
+		$time_gmt_time   = mysql2date( 'G', $time );
+		$time_local_time = GFCommon::get_local_timestamp( $time_gmt_time );
 
 		$tests = array(
 			GVCommon::format_date( $date_created, 'raw=1') => $date_created,
@@ -154,6 +167,10 @@ class GVCommon_Test extends GV_UnitTestCase {
 			GVCommon::format_date( $date_created, array('diff' => true ) ) => sprintf( '%s ago', human_time_diff( $entry_gmt_time ) ),
 			GVCommon::format_date( $date_created, 'diff=1&format=%s is so long ago' ) => sprintf( '%s is so long ago', human_time_diff( $entry_gmt_time ) ),
 			GVCommon::format_date( $date_created, array('diff' => 1, 'format' => '%s is so long ago' ) ) => sprintf( '%s is so long ago', human_time_diff( $entry_gmt_time ) ),
+
+			// 2 days and 2 hours from now
+			GVCommon::format_date( $datepicker, 'diff=1&human=1') => sprintf( '%s from now', human_time_diff( $datepicker_local_time ) ),
+			GVCommon::format_date( $time, 'diff=1&human=1&time=1') => sprintf( '%s from now', human_time_diff( $time_local_time ) ),
 
 			// Relative should NOT process other modifiers
 			GVCommon::format_date( $date_created, 'diff=1&time=1' ) => sprintf( '%s ago', human_time_diff( $entry_gmt_time ) ),


### PR DESCRIPTION
- FIxes https://github.com/GravityKit/GravityView/issues/1990
- I had to edit the `GravityView_Field_Date` class because it was overriding the human modifier by running the function again without the new arguments and i couldn't remove the filter `gravityview/merge_tags/modifiers/value` as it was happening after the human modifier function.


💾 [Build file](https://www.dropbox.com/scl/fi/55s0yfg7q7x5h663r349q/gravityview-2.28.0-cb02ebddc.zip?rlkey=nmffl5isaq265aj4fzxsel67g&dl=1) (cb02ebddc).