### PR TITLE
Single entry in lightbox

### DIFF
--- a/assets/js/admin-views.js
+++ b/assets/js/admin-views.js
@@ -1003,6 +1003,8 @@
 				open: function () {
 					$( '<div class="gv-overlay" />' ).prependTo( '#wpwrap' );
 
+					$( document.body ).trigger( 'gravityview/dialog-opened', thisDialog );
+
 					vcfg.toggleCheckboxes( thisDialog );
 					vcfg.setupFieldDetails( thisDialog );
 

--- a/assets/js/fe-views.js
+++ b/assets/js/fe-views.js
@@ -34,7 +34,7 @@ jQuery( function ( $ ) {
 
 			this.number_range();
 
-			this.lightbox();
+			this.iframe();
 		},
 
 		/**
@@ -182,28 +182,24 @@ jQuery( function ( $ ) {
 		},
 
 		/**
-		 * Listen for messages from the iframe and close the lightbox if requested.
+		 * Listen for messages from the iframe and perform various actions.
 		 *
 		 * @since TBD
 		 */
-		lightbox: function () {
+		iframe: function () {
 			window.addEventListener( 'message', function ( event ) {
-				if ( event.data?.closeLightbox && window.Fancybox ) {
+				if ( event.data?.closeFancybox && window.Fancybox ) {
+					history.replaceState( null, null, ' ' );
+
 					Fancybox.close();
 				}
 
 				if ( event.data?.reloadPage ) {
-					if ( window.location.hash ) {
-						history.pushState( '', document.title, window.location.pathname + window.location.search );
-					}
-
-					location.reload();
-
-					return;
+					return location.reload();
 				}
 
-				if ( event.data?.redirectUrl ) {
-					window.location = event.data.redirectUrl;
+				if ( event.data?.redirectToUrl ) {
+					return window.location = event.data.redirectToUrl;
 				}
 			} );
 		}

--- a/assets/js/fe-views.js
+++ b/assets/js/fe-views.js
@@ -188,6 +188,10 @@ jQuery( function ( $ ) {
 		 */
 		iframe: function () {
 			window.addEventListener( 'message', function ( event ) {
+				if ( event.data?.removeHash ) {
+					history.replaceState( null, null, ' ' );
+				}
+
 				if ( event.data?.closeFancybox && window.Fancybox ) {
 					history.replaceState( null, null, ' ' );
 

--- a/assets/js/fe-views.js
+++ b/assets/js/fe-views.js
@@ -33,6 +33,8 @@ jQuery( function ( $ ) {
 			$( 'a.gv-sort' ).on( 'click', this.multiclick_sort );
 
 			this.number_range();
+
+			this.lightbox();
 		},
 
 		/**
@@ -177,6 +179,33 @@ jQuery( function ( $ ) {
 					}.bind( this ), 2 );
 				} )
 				.find( 'input' ).trigger( 'change' ); // Initial trigger.
+		},
+
+		/**
+		 * Listen for messages from the iframe and close the lightbox if requested.
+		 *
+		 * @since TBD
+		 */
+		lightbox: function () {
+			window.addEventListener( 'message', function ( event ) {
+				if ( event.data?.closeLightbox && window.Fancybox ) {
+					Fancybox.close();
+				}
+
+				if ( event.data?.reloadPage ) {
+					if ( window.location.hash ) {
+						history.pushState( '', document.title, window.location.pathname + window.location.search );
+					}
+
+					location.reload();
+
+					return;
+				}
+
+				if ( event.data?.redirectUrl ) {
+					window.location = event.data.redirectUrl;
+				}
+			} );
 		}
 	};
 

--- a/future/includes/class-gv-plugin.php
+++ b/future/includes/class-gv-plugin.php
@@ -226,6 +226,7 @@ final class Plugin {
 		include_once $this->dir( 'includes/extensions/duplicate-entry/class-duplicate-entry.php' );
 		include_once $this->dir( 'includes/extensions/entry-notes/class-gravityview-field-notes.php' );
 		include_once $this->dir( 'includes/extensions/lightbox/class-gravityview-lightbox.php' );
+		include_once $this->dir( 'includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php' );
 
 		// Load WordPress Widgets
 		include_once $this->dir( 'includes/wordpress-widgets/register-wordpress-widgets.php' );

--- a/includes/admin/class.render.settings.php
+++ b/includes/admin/class.render.settings.php
@@ -147,16 +147,17 @@ class GravityView_Render_Settings {
 		 */
 		$field_options = apply_filters( "gravityview_template_{$input_type}_options", $field_options, $template_id, $field_id, $context, $input_type, $form_id );
 
-		if ( 'directory' === $context && isset( $field_options['show_as_link'] ) && ! isset( $field_options['new_window'] ) ) {
-			$field_options['new_window'] = array(
-				'type'     => 'checkbox',
-				'label'    => __( 'Open link in a new tab or window?', 'gk-gravityview' ),
-				'value'    => false,
-				'context'  => 'directory',
-				'requires' => 'show_as_link',
-				'priority' => 101,
-				'group'    => 'display',
-			);
+		if ( 'directory' === $context && isset( $field_options['show_as_link'] ) ) {
+			$field = new class extends GravityView_Field {
+				public function __construct() {
+				}
+			};
+
+			$field->add_field_support( 'new_window', $field_options );
+			$field->add_field_support( 'lightbox', $field_options );
+
+			$field_options['lightbox']   = array_merge( $field_options['lightbox'], [ 'requires' => 'show_as_link', 'priority' => 101 ] );
+			$field_options['new_window'] = array_merge( $field_options['new_window'], [ 'requires' => 'show_as_link', 'priority' => 102 ] );
 		}
 
 		if ( $grouped ) {

--- a/includes/extensions/delete-entry/class-delete-entry.php
+++ b/includes/extensions/delete-entry/class-delete-entry.php
@@ -383,20 +383,20 @@ final class GravityView_Delete_Entry {
 
 			gravityview()->log->debug( 'Delete entry failed: there was no entry with the entry slug {entry_slug}', array( 'entry_slug' => $entry_slug ) );
 
-			$this->_redirect_and_exit( $delete_redirect_base, __( 'The entry does not exist.', 'gk-gravityview' ), 'error' );
+			return $this->_redirect_and_exit( $delete_redirect_base, __( 'The entry does not exist.', 'gk-gravityview' ), 'error' );
 		}
 
 		$has_permission = $this->user_can_delete_entry( $entry, \GV\Utils::_GET( 'gvid', \GV\Utils::_GET( 'view_id' ) ) );
 
 		if ( is_wp_error( $has_permission ) ) {
-			$this->_redirect_and_exit( $delete_redirect_base, $has_permission->get_error_message(), 'error' );
+			return $this->_redirect_and_exit( $delete_redirect_base, $has_permission->get_error_message(), 'error' );
 		}
 
 		// Delete the entry
 		$delete_response = $this->delete_or_trash_entry( $entry );
 
 		if ( is_wp_error( $delete_response ) ) {
-			$this->_redirect_and_exit( $delete_redirect_base, $delete_response->get_error_message(), 'error' );
+			return $this->_redirect_and_exit( $delete_redirect_base, $delete_response->get_error_message(), 'error' );
 		}
 
 		if ( self::REDIRECT_TO_URL_VALUE === (int) $view->settings->get( 'delete_redirect' ) ) {
@@ -405,11 +405,11 @@ final class GravityView_Delete_Entry {
 			$redirect_url_setting = $view->settings->get( 'delete_redirect_url' );
 			$redirect_url         = GFCommon::replace_variables( $redirect_url_setting, $form, $entry, false, false, false, 'text' );
 
-			$this->_redirect_and_exit( $redirect_url, '', '', false );
+			return $this->_redirect_and_exit( $redirect_url, '', '', false );
 		}
 
 		// Redirect to multiple entries
-		$this->_redirect_and_exit( $delete_redirect_base, '', $delete_response, true );
+		return $this->_redirect_and_exit( $delete_redirect_base, '', $delete_response, true );
 	}
 
 	/**
@@ -423,6 +423,9 @@ final class GravityView_Delete_Entry {
 	 * @param bool   $safe_redirect Whether to use wp_safe_redirect() or not.
 	 */
 	private function _redirect_and_exit( $url, $message = '', $status = '', $safe_redirect = true ) {
+		if ( ! apply_filters( 'wp_redirect', $url ) ) {
+			return;
+		}
 
 		$delete_redirect_args = array(
 			'status'  => $status,

--- a/includes/extensions/duplicate-entry/class-duplicate-entry.php
+++ b/includes/extensions/duplicate-entry/class-duplicate-entry.php
@@ -373,9 +373,7 @@ final class GravityView_Duplicate_Entry {
 		}
 
 		// Make sure it's a GravityView request
-		$valid_nonce_key = wp_verify_nonce( \GV\Utils::_GET( 'duplicate' ), self::get_nonce_key( $_GET['entry_id'] ) );
-
-		if ( ! $valid_nonce_key ) {
+		if ( ! $this->verify_nonce() ) {
 			gravityview()->log->debug( 'Duplicate entry not processed: nonce validation failed.' );
 			return;
 		}
@@ -880,7 +878,7 @@ final class GravityView_Duplicate_Entry {
 			);
 		}
 
-		if ( ! wp_verify_nonce( \GV\Utils::_GET( 'duplicate' ), self::get_nonce_key( $entry_id = \GV\Utils::_GET( 'entry_id' ) ) ) ) {
+		if ( ! $this->verify_nonce() ) {
 			return;
 		}
 

--- a/includes/extensions/duplicate-entry/class-duplicate-entry.php
+++ b/includes/extensions/duplicate-entry/class-duplicate-entry.php
@@ -437,7 +437,7 @@ final class GravityView_Duplicate_Entry {
 		$redirect_to_base = esc_url_raw( remove_query_arg( array( 'action', 'gvid', 'entry_id' ) ) );
 		$redirect_to      = add_query_arg( $messages, $redirect_to_base );
 
-		if ( defined( 'DOING_GRAVITYVIEW_TESTS' ) ) {
+		if ( defined( 'DOING_GRAVITYVIEW_TESTS' ) || ! apply_filters( 'wp_redirect', $redirect_to ) ) {
 			return $redirect_to;
 		}
 

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry-request.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry-request.php
@@ -1,0 +1,47 @@
+<?php
+
+use GV\Frontend_Request;
+use GV\GF_Entry;
+use GV\View;
+
+class GravityView_Lightbox_Entry_Request extends Frontend_Request {
+	/**
+	 * Class constructor.
+	 *
+	 * @param View     $view
+	 * @param GF_Entry $entry
+	 */
+	public function __construct( View $view, GF_Entry $entry ) {
+		$this->entry = $entry;
+		$this->view  = $view;
+
+		parent::__construct();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since TBD
+	 */
+	public function is_entry( $form_id = 0 ) {
+		return $this->entry;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since TBD
+	 */
+	public function is_view( $return_view = true ) {
+		return $return_view ? $this->view : true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since TBD
+	 */
+	public function is_renderable(): bool {
+		return true;
+	}
+}

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry-request.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry-request.php
@@ -6,6 +6,24 @@ use GV\View;
 
 class GravityView_Lightbox_Entry_Request extends Frontend_Request {
 	/**
+	 * Gravity Forms entry object.
+	 *
+	 * @since TBD
+	 *
+	 * @var GF_Entry
+	 */
+	private $entry;
+
+	/**
+	 * GravityView View object.
+	 *
+	 * @since TBD
+	 *
+	 * @var View
+	 */
+	private $view;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param View     $view

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -263,7 +263,7 @@ class GravityView_Lightbox_Entry {
 	}
 
 	/**
-	 * Processes the delete entry request.
+	 * Processes the delete entry action.
 	 *
 	 * @since TBD
 	 *

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -157,8 +157,8 @@ class GravityView_Lightbox_Entry {
 	 *
 	 * @since TBD
 	 *
-	 * @param int $view_id  The View object.
-	 * @param int $entry_id The entry object.
+	 * @param int $view_id  The View ID.
+	 * @param int $entry_id The entry ID.
 	 *
 	 * @return string
 	 */
@@ -168,8 +168,45 @@ class GravityView_Lightbox_Entry {
 			self::REST_NAMESPACE,
 			self::REST_VERSION,
 			$view_id,
-			$entry_id,
+			$entry_id
 		);
+	}
+
+	/**
+	 * Returns REST endpoint for specific View and entry.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_rest_endpoint_from_request() {
+		preg_match(
+			sprintf(
+				'#%s/v%s/(?P<endpoint>%s)#',
+				self::REST_NAMESPACE,
+				self::REST_VERSION,
+				self::REST_ENDPOINT_REGEX
+			),
+			urldecode( $_SERVER['REQUEST_URI'] ?? '' ),
+			$matches
+		);
+
+		return $matches['endpoint'] ?? null;
+	}
+
+	/**
+	 * Returns the View and entry IDs from the REST endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $endpoint The REST endpoint.
+	 *
+	 * @return array{view_id:string, entry_id:string}|null
+	 */
+	public function get_view_and_entry_from_rest_endpoint( $endpoint ) {
+		preg_match( self::REST_ENDPOINT_REGEX, $endpoint, $matches );
+
+		return ! empty( $matches ) ? [ 'view_id' => $matches['view_id'], 'entry_id' => $matches['entry_id'] ] : null;
 	}
 
 	/**
@@ -188,8 +225,7 @@ class GravityView_Lightbox_Entry {
 	 */
 	public function modify_entry_link( $link, $href, $entry, $field_settings ) {
 		$view          = GravityView_View::getInstance();
-		$rest_endpoint = $this->get_rest_endpoint( $view->view_id, $entry['id'] );
-		$is_rest       = strpos( urldecode( $_SERVER['REQUEST_URI'] ?? '' ), $rest_endpoint ) !== false;
+		$is_rest       = ! empty( $this->get_rest_endpoint_from_request() );
 		$is_edit       = 'edit_link' === ( $field_settings['id'] ?? '' );
 
 		if ( ! (int) ( $field_settings['lightbox'] ?? 0 ) && ! $is_rest ) {

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -1,0 +1,290 @@
+<?php
+
+use GV\Edit_Entry_Renderer;
+use GV\Entry_Renderer;
+use GV\GF_Entry;
+use GV\View;
+
+class GravityView_Lightbox_Entry {
+	/**
+	 * The REST namespace used for the single entry lightbox view.
+	 *
+	 * @since TBD
+	 */
+	const REST_NAMESPACE = 'gravityview/v1';
+
+	/**
+	 * Class constructor.
+	 *
+	 * @since TBD
+	 */
+	public function __construct() {
+		require_once 'class-gravityview-lightbox-entry-request.php';
+
+		add_filter( 'gk/foundation/rest/routes', [ $this, 'register_rest_routes' ] );
+		add_filter( 'gravityview_field_entry_link', [ $this, 'modify_entry_link' ], 10, 4 );
+		add_filter( 'gk/foundation/inline-scripts', [ $this, 'enqueue_view_editor_script' ] );
+	}
+
+	/**
+	 * Registers the REST route for the single entry lightbox view.
+	 *
+	 * @used-by `gk/foundation/rest/routes` filter.
+	 *
+	 * @since   TBD
+	 *
+	 * @param array[] $routes The registered REST routes.
+	 *
+	 * @return array
+	 */
+	public function register_rest_routes( $routes ) {
+		$routes = $routes ?? [];
+
+		$routes[] = [
+			'namespace'           => explode( '/v', self::REST_NAMESPACE )[0],
+			'version'             => explode( '/v', self::REST_NAMESPACE )[1],
+			'endpoint'            => sprintf(
+				'view/%s/entry/%s',
+				'(?P<view_id>[0-9]+)',
+				'(?P<entry_id>[0-9]+)' ),
+			'methods'             => [ 'GET', 'POST' ],
+			'callback'            => [ $this, 'render_entry' ],
+			'permission_callback' => '__return_true', // WP will handle the nonce and Entry_Renderer::render() will take care of permissions.
+		];
+
+		return $routes;
+	}
+
+	/**
+	 * Modify attributes for the single or entry link to open in a lightbox.
+	 *
+	 * @used-by `gravityview_field_entry_link` filter.
+	 *
+	 * @since   TBD
+	 *
+	 * @param string $link           The entry link (HTML markup).
+	 * @param string $href           The entry link URL.
+	 * @param array  $entry          The entry data.
+	 * @param array  $field_settings The Link to Single Entry field settings.
+	 *
+	 * @return string
+	 */
+	public function modify_entry_link( $link, $href, $entry, $field_settings ) {
+		$view          = GravityView_View::getInstance();
+		$href          = self::REST_NAMESPACE . "/view/{$view->getViewId()}/entry/{$entry['id']}";
+		$is_rest       = $href === ltrim( $_REQUEST['rest_route'] ?? '', '/' );
+		$is_edit_entry = 'edit_link' === ( $field_settings['id'] ?? '' );
+
+		if ( ! (int) ( $field_settings['lightbox'] ?? 0 ) && ! $is_rest ) {
+			return $link;
+		}
+
+		$args = [
+			'_wpnonce' => wp_create_nonce( 'wp_rest' ),
+		];
+
+		if ( $is_edit_entry ) {
+			$args['edit'] = wp_create_nonce( GravityView_Edit_Entry::get_nonce_key( $view->view_id, $view->form_id, $entry['id'] ) );
+		}
+
+		$href = add_query_arg(
+			$args,
+			rest_url( $href ),
+		);
+
+		$atts = [
+			'class'         => ( $link_atts['class'] ?? '' ) . ' gravityview-fancybox',
+			'rel'           => 'nofollow',
+			'data-type'     => 'iframe',
+			'data-fancybox' => $view->getCurrentField()['UID'],
+		];
+
+		return gravityview_get_link(
+			$href,
+			$is_edit_entry ? $field_settings['edit_link'] : $field_settings['entry_link_text'],
+			$is_rest ? [] : $atts // Do not add the attributes if the link is being rendered in the REST context.
+		);
+	}
+
+	/**
+	 * Renders the single or edit entry view.
+	 *
+	 * @used-by `gk/foundation/rest/routes` filter.
+	 *
+	 * @since   TBD
+	 *
+	 * @param GravityView_Lightbox_Entry_Request $request The request object.
+	 *
+	 * @return void
+	 */
+	public function render_entry( $request ) {
+		$view_id  = $request->get_param( 'view_id' ) ?? 0;
+		$entry_id = $request->get_param( 'entry_id' ) ?? 0;
+
+		$view      = View::by_id( $view_id );
+		$entry     = GF_Entry::by_id( $entry_id );
+		$form      = GVCommon::get_form( $entry['form_id'] ?? 0 );
+		$is_edit   = $request->get_param( 'edit' ) ?? null;
+		$is_delete = $request->get_param( 'delete' ) ?? null;
+
+		if ( ! $view || ! $entry || ! $form ) {
+			gravityview()->log->error( "Unable to find View ID {$view_id} and/or entry ID {$entry_id}." );
+
+			return;
+		}
+
+		$view_data = GravityView_View_Data::getInstance();
+		$view_data->add_view( $view->ID );
+
+		if ( $is_edit && wp_verify_nonce( $is_edit, GravityView_Edit_Entry::get_nonce_key( $view->ID, $form['id'], $entry->ID ) ) ) {
+			add_filter( 'gravityview/edit_entry/verify_nonce', '__return_true' );
+		}
+
+		ob_start();
+
+		add_filter( 'gravityview_go_back_url', '__return_false' );
+
+		if ( $is_delete ) {
+			add_filter( 'wp_redirect', '__return_false' );
+
+			do_action( 'wp' ); // Entry deletion hooks to the `wp` action.
+
+			$redirect_url = $view->settings->get( 'delete_redirect_url', '' );
+			$reload_page  = GravityView_Delete_Entry::REDIRECT_TO_MULTIPLE_ENTRIES_VALUE === (int) $view->settings->get( 'delete_redirect', GravityView_Delete_Entry::REDIRECT_TO_MULTIPLE_ENTRIES_VALUE );
+
+			?>
+				<script type="text/javascript">
+					window.parent.postMessage( {
+						reloadPage: <?php echo $reload_page ? 'true' : 'false'; ?>,
+						redirectUrl: '<?php echo esc_url( $redirect_url ); ?>',
+					} );
+				</script>
+			<?php
+
+			return new WP_REST_Response( null, 200, [ 'Content-Type' => 'text/html' ] );
+		}
+
+		GravityView_frontend::getInstance()->setGvOutputData( $view_data );
+		GravityView_frontend::getInstance()->add_scripts_and_styles();
+
+		$title = do_shortcode(
+			GravityView_API::replace_variables(
+				$view->settings->get( 'single_title', '' ),
+				$form,
+				$entry
+			)
+		);
+
+		$entry_renderer = $is_edit ? new Edit_Entry_Renderer() : new Entry_Renderer();
+
+		$content = $entry_renderer->render(
+			$entry,
+			$view,
+			new GravityView_Lightbox_Entry_Request( $view, $entry )
+		);
+
+		?>
+		<html lang="<?php echo get_bloginfo( 'language' ); ?>">
+			<head>
+				<title><?php echo $title; ?></title>
+
+				<?php wp_head(); ?>
+
+				<style>
+					<?php echo $view->settings->get( 'custom_css', '' ); ?>
+				</style>
+
+				<script type="text/javascript">
+					<?php echo $view->settings->get( 'custom_javascript', '' ); ?>
+				</script>
+			</head>
+
+			<body>
+				<?php echo $content; ?>
+			</body>
+
+			<?php wp_print_scripts(); ?>
+			<?php wp_print_styles(); ?>
+		</html>
+		<?php
+
+		// Set the response content type and let WP take care of returning the buffered content.
+		return new WP_REST_Response( null, 200, [ 'Content-Type' => 'text/html' ] );
+	}
+
+	/**
+	 * Enqueues View editor script that handles the lightbox entry settings.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $scripts The registered scripts.
+	 *
+	 * @return void
+	 */
+	public function enqueue_view_editor_script( $scripts ) {
+		global $post;
+
+		if ( ! $post instanceof WP_Post && 'gravityview' !== $post->post_type && 'edit' !== $post->filter ) {
+			return $scripts;
+		}
+
+		$scripts[] = [
+			'script' => <<<JS
+				// Disable "open in new tab/window" input when "open in lightbox" is checked, and vice versa.
+				jQuery( document ).ready( function ( jQuery ) {
+					function handleInputState( dialog ) {
+						const newWindow = dialog.find( '.gv-setting-container-new_window input' );
+						const lightbox = dialog.find( '.gv-setting-container-lightbox input' );
+				
+						function updateState( active, inactive ) {
+							if ( active.is( ':checked' ) ) {
+								inactive.prop( 'checked', false ).prop( 'disabled', true );
+							} else {
+								inactive.prop( 'disabled', false );
+							}
+						}
+				
+						updateState( newWindow, lightbox );
+						updateState( lightbox, newWindow );
+					}
+					
+					function handleChange( changedInput, otherInput ) {
+						otherInput.prop( 'checked', false );
+
+						// This is a workaround for the element not being disabled probably due to interference from other JS.
+						setTimeout( function () {
+							otherInput.prop( 'disabled', changedInput.is( ':checked' ) );
+						}, 10 );
+					}
+					
+					jQuery( document ).on( 'gravityview/dialog-opened', function ( event, thisDialog ) {
+						const dialog = jQuery( thisDialog );
+				
+						handleInputState( dialog );
+				
+						const newWindow = dialog.find( '.gv-setting-container-new_window input' );
+						const lightbox = dialog.find( '.gv-setting-container-lightbox input' );
+				
+						newWindow.on( 'change.lightboxEntry', function () {
+							handleChange( jQuery( this ), lightbox );
+						} );
+				
+						lightbox.on( 'change.lightboxEntry', function () {
+							handleChange( jQuery( this ), newWindow );
+						} );
+					} );
+				
+					jQuery( document ).on( 'gravityview/dialog-closed', function ( event, thisDialog ) {
+						jQuery( thisDialog ).find( '.gv-setting-container-new_window input, .gv-setting-container-lightbox input' )
+							.off( 'change.lightboxEntry' );
+					} );
+				} );
+JS,
+			'deps'   => [ 'jquery' ],
+		];
+
+		return $scripts;
+	}
+}
+
+new GravityView_Lightbox_Entry();

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -115,7 +115,7 @@ class GravityView_Lightbox_Entry {
 	 * @return string
 	 */
 	public function rewrite_directory_link( $link ) {
-		if ( ! gravityview()->request instanceof GravityView_Lightbox_Entry_Request && ! $skip_rest_check ) {
+		if ( ! gravityview()->request instanceof GravityView_Lightbox_Entry_Request ) {
 			return $link;
 		}
 

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -143,6 +143,24 @@ class GravityView_Lightbox_Entry {
 			add_filter( 'gravityview/view/links/directory', function () use ( $view, $entry ) {
 				return rest_url( $this->get_rest_endpoint( $view->ID, $entry->ID ) );
 			} );
+
+			if ( in_array( $view->settings->get( 'edit_redirect' ), [ '1', '2' ] ) ) {
+				add_filter( 'gravityview/edit_entry/success', function ( $message ) use ( $view ) {
+					$reload_page     = 1 === (int) $view->settings->get( 'edit_redirect' ) ? 'true' : 'false';
+					$redirect_to_url = 2 === (int) $view->settings->get( 'edit_redirect' ) ? esc_url( $view->settings->get( 'edit_redirect_url', '' ) ) : '';
+
+					return <<<JS
+						<style>.gv-notice { display: none; }</style>
+						<script>
+							window.parent.postMessage( {
+							    removeHash: {$reload_page},
+								reloadPage: {$reload_page},
+								redirectToUrl: '{$redirect_to_url}',
+							} );
+						</script>
+					JS;
+				} );
+			}
 		}
 
 		ob_start();

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -270,6 +270,8 @@ class GravityView_Lightbox_Entry {
 
 		$entry_renderer = 'edit' === $type ? new Edit_Entry_Renderer() : new Entry_Renderer();
 
+		do_action( 'wp_enqueue_scripts' );
+
 		ob_start();
 
 		$title = do_shortcode(

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -24,6 +24,7 @@ class GravityView_Lightbox_Entry {
 		add_filter( 'gk/foundation/rest/routes', [ $this, 'register_rest_routes' ] );
 		add_filter( 'gravityview_field_entry_link', [ $this, 'modify_entry_link' ], 10, 4 );
 		add_filter( 'gk/foundation/inline-scripts', [ $this, 'enqueue_view_editor_script' ] );
+		add_filter( 'gravityview/view/links/directory', [ $this, 'rewrite_directory_link' ] );
 	}
 
 	/**
@@ -97,6 +98,30 @@ class GravityView_Lightbox_Entry {
 			$entry,
 			$form
 		);
+	}
+
+	/**
+	 * Rewrites the directory link when inside the REST context.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $link The directory link.
+	 *
+	 * @return string
+	 */
+	public function rewrite_directory_link( $link ) {
+		if ( ! gravityview()->request instanceof GravityView_Lightbox_Entry_Request && ! $skip_rest_check ) {
+			return $link;
+		}
+
+		$view  = gravityview()->request->is_view();
+		$entry = gravityview()->request->is_entry();
+
+		if ( ! $view || ! $entry ) {
+			return $link;
+		}
+
+		return $this->get_rest_directory_link( $view->ID, $entry->ID );
 	}
 
 	/**

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -72,7 +72,7 @@ class GravityView_Lightbox_Entry {
 	public function modify_entry_link( $link, $href, $entry, $field_settings ) {
 		$view          = GravityView_View::getInstance();
 		$rest_endpoint = $this->get_rest_endpoint( $view->view_id, $entry['id'] );
-		$is_rest       = strpos( $_SERVER['REQUEST_URI'] ?? '', $rest_endpoint ) !== false;
+		$is_rest       = strpos( urldecode( $_SERVER['REQUEST_URI'] ?? '' ), $rest_endpoint ) !== false;
 		$is_edit_entry = 'edit_link' === ( $field_settings['id'] ?? '' );
 
 		if ( ! (int) ( $field_settings['lightbox'] ?? 0 ) && ! $is_rest ) {

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -354,6 +354,8 @@ class GravityView_Lightbox_Entry {
 
 		$entry_renderer = 'edit' === $type ? new Edit_Entry_Renderer() : new Entry_Renderer();
 
+		do_action( 'wp' );
+
 		do_action( 'wp_enqueue_scripts' );
 
 		ob_start();

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -11,7 +11,21 @@ class GravityView_Lightbox_Entry {
 	 *
 	 * @since TBD
 	 */
-	const REST_NAMESPACE = 'gravityview/v1';
+	const REST_NAMESPACE = 'gravityview';
+
+	/**
+	 * The REST version used for the single entry lightbox view.
+	 *
+	 * @since TBD
+	 */
+	const REST_VERSION = 1;
+
+	/**
+	 * Regex used to match the REST endpoint.
+	 *
+	 * @since TBD
+	 */
+	const REST_ENDPOINT_REGEX = 'view/(?P<view_id>[0-9]+)/entry/(?P<entry_id>[0-9]+)';
 
 	/**
 	 * Class constructor.
@@ -42,12 +56,9 @@ class GravityView_Lightbox_Entry {
 		$routes = $routes ?? [];
 
 		$routes[] = [
-			'namespace'           => explode( '/v', self::REST_NAMESPACE )[0],
-			'version'             => explode( '/v', self::REST_NAMESPACE )[1],
-			'endpoint'            => sprintf(
-				'view/%s/entry/%s',
-				'(?P<view_id>[0-9]+)',
-				'(?P<entry_id>[0-9]+)' ),
+			'namespace'           => self::REST_NAMESPACE,
+			'version'             => self::REST_VERSION,
+			'endpoint'            => self::REST_ENDPOINT_REGEX,
 			'methods'             => [ 'GET', 'POST' ],
 			'callback'            => [ $this, 'process_rest_request' ],
 			'permission_callback' => '__return_true', // WP will handle the nonce and Entry_Renderer::render() will take care of permissions.
@@ -152,7 +163,13 @@ class GravityView_Lightbox_Entry {
 	 * @return string
 	 */
 	public function get_rest_endpoint( $view_id, $entry_id ) {
-		return self::REST_NAMESPACE . "/view/{$view_id}/entry/{$entry_id}";
+		return sprintf(
+			'%s/v%s/view/%s/entry/%s',
+			self::REST_NAMESPACE,
+			self::REST_VERSION,
+			$view_id,
+			$entry_id,
+		);
 	}
 
 	/**

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -100,6 +100,32 @@ class GravityView_Lightbox_Entry {
 	}
 
 	/**
+	 * Returns REST directory link for specific View and entry.
+	 *
+	 * @return string
+	 */
+	public function get_rest_directory_link( $view_id, $entry_id ) {
+		return add_query_arg(
+			[ '_wpnonce' => wp_create_nonce( 'wp_rest' ) ],
+			rest_url( $this->get_rest_endpoint( $view_id, $entry_id ) ),
+		);
+	}
+
+	/**
+	 * Returns REST endpoint for specific View and entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $view_id  The View object.
+	 * @param int $entry_id The entry object.
+	 *
+	 * @return string
+	 */
+	public function get_rest_endpoint( $view_id, $entry_id ) {
+		return self::REST_NAMESPACE . "/view/{$view_id}/entry/{$entry_id}";
+	}
+
+	/**
 	 * Modifies Single or Edit Entry links to open inside lightbox.
 	 *
 	 * @used-by `gravityview_field_entry_link` filter.
@@ -123,24 +149,22 @@ class GravityView_Lightbox_Entry {
 			return $link;
 		}
 
-		$args = [
-			'_wpnonce' => wp_create_nonce( 'wp_rest' ),
-		];
+		$directory_link = $this->get_rest_directory_link( $view->view_id, $entry['id'] );
 
 		if ( $is_edit ) {
-			$args['edit'] = wp_create_nonce(
-				GravityView_Edit_Entry::get_nonce_key(
-					$view->view_id,
-					$view->form_id,
-					$entry['id']
-				)
+			$directory_link = add_query_arg(
+				[
+					'edit' => wp_create_nonce(
+						GravityView_Edit_Entry::get_nonce_key(
+							$view->view_id,
+							$view->form_id,
+							$entry['id']
+						)
+					),
+				],
+				$directory_link,
 			);
 		}
-
-		$href = add_query_arg(
-			$args,
-			rest_url( $rest_endpoint ),
-		);
 
 		$atts = [
 			'class'         => ( $link_atts['class'] ?? '' ) . ' gravityview-fancybox',
@@ -157,7 +181,7 @@ class GravityView_Lightbox_Entry {
 		}
 
 		return gravityview_get_link(
-			$href,
+			$directory_link,
 			$link_text,
 			$is_rest ? [] : $atts // Do not add the attributes if the link is being rendered in the REST context.
 		);
@@ -318,20 +342,6 @@ class GravityView_Lightbox_Entry {
 			200,
 			[ 'Content-Type' => 'text/html' ]
 		);
-	}
-
-	/**
-	 * Returns REST endpoint for specific View and entry.
-	 *
-	 * @since TBD
-	 *
-	 * @param int $view_id  The View object.
-	 * @param int $entry_id The entry object.
-	 *
-	 * @return string
-	 */
-	public function get_rest_endpoint( $view_id, $entry_id ) {
-		return self::REST_NAMESPACE . "/view/{$view_id}/entry/{$entry_id}";
 	}
 
 	/**

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -224,7 +224,7 @@ class GravityView_Lightbox_Entry {
 	public function enqueue_view_editor_script( $scripts ) {
 		global $post;
 
-		if ( ! $post instanceof WP_Post && 'gravityview' !== $post->post_type && 'edit' !== $post->filter ) {
+		if ( ! $post || ( ! $post instanceof WP_Post && 'gravityview' !== $post->post_type && 'edit' !== $post->filter ) ) {
 			return $scripts;
 		}
 

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -137,6 +137,7 @@ class GravityView_Lightbox_Entry {
 		$view_data->add_view( $view->ID );
 
 		if ( $is_edit && wp_verify_nonce( $is_edit, GravityView_Edit_Entry::get_nonce_key( $view->ID, $form['id'], $entry->ID ) ) ) {
+			add_filter( 'gravityview/edit_entry/cancel_onclick', '__return_null' );
 			add_filter( 'gravityview/edit_entry/verify_nonce', '__return_true' );
 
 			add_filter( 'gravityview/view/links/directory', function () use ( $view, $entry ) {
@@ -153,16 +154,18 @@ class GravityView_Lightbox_Entry {
 
 			do_action( 'wp' ); // Entry deletion hooks to the `wp` action.
 
-			$redirect_url = $view->settings->get( 'delete_redirect_url', '' );
-			$reload_page  = GravityView_Delete_Entry::REDIRECT_TO_MULTIPLE_ENTRIES_VALUE === (int) $view->settings->get( 'delete_redirect', GravityView_Delete_Entry::REDIRECT_TO_MULTIPLE_ENTRIES_VALUE );
+			$reload_page     = GravityView_Delete_Entry::REDIRECT_TO_MULTIPLE_ENTRIES_VALUE === (int) $view->settings->get( 'delete_redirect' );
+			$redirect_to_url = GravityView_Delete_Entry::REDIRECT_TO_URL_VALUE === (int) $view->settings->get( 'delete_redirect' );
+			$redirect_url    = esc_url( $view->settings->get( 'delete_redirect_url', '' ) );
 
 			?>
-				<script type="text/javascript">
-					window.parent.postMessage( {
-						reloadPage: <?php echo $reload_page ? 'true' : 'false'; ?>,
-						redirectUrl: '<?php echo esc_url( $redirect_url ); ?>',
-					} );
-				</script>
+			<script type="text/javascript">
+				window.parent.postMessage( {
+					closeFancybox: true,
+					reloadPage: <?php echo $reload_page ? 'true' : 'false'; ?>,
+					redirectToUrl: '<?php echo $redirect_to_url ? $redirect_url : ''; ?>',
+				} );
+			</script>
 			<?php
 
 			return new WP_REST_Response( null, 200, [ 'Content-Type' => 'text/html' ] );

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -36,7 +36,7 @@ class GravityView_Lightbox_Entry {
 		require_once 'class-gravityview-lightbox-entry-request.php';
 
 		add_filter( 'gk/foundation/rest/routes', [ $this, 'register_rest_routes' ] );
-		add_filter( 'gravityview_field_entry_link', [ $this, 'modify_entry_link' ], 10, 4 );
+		add_filter( 'gravityview_field_entry_link', [ $this, 'rewrite_entry_link' ], 10, 4 );
 		add_filter( 'gk/foundation/inline-scripts', [ $this, 'enqueue_view_editor_script' ] );
 		add_filter( 'gravityview/view/links/directory', [ $this, 'rewrite_directory_link' ] );
 		add_filter( 'gform_get_form_confirmation_filter', [ $this, 'process_gravity_forms_form_submission' ] );
@@ -212,7 +212,7 @@ class GravityView_Lightbox_Entry {
 	}
 
 	/**
-	 * Modifies Single or Edit Entry links to open inside lightbox.
+	 * Rewrites Single or Edit Entry links to open inside lightbox.
 	 *
 	 * @used-by `gravityview_field_entry_link` filter.
 	 *
@@ -225,10 +225,10 @@ class GravityView_Lightbox_Entry {
 	 *
 	 * @return string
 	 */
-	public function modify_entry_link( $link, $href, $entry, $field_settings ) {
-		$view          = GravityView_View::getInstance();
-		$is_rest       = ! empty( $this->get_rest_endpoint_from_request() );
-		$is_edit       = 'edit_link' === ( $field_settings['id'] ?? '' );
+	public function rewrite_entry_link( $link, $href, $entry, $field_settings ) {
+		$view    = GravityView_View::getInstance();
+		$is_rest = ! empty( $this->get_rest_endpoint_from_request() );
+		$is_edit = 'edit_link' === ( $field_settings['id'] ?? '' );
 
 		if ( ! (int) ( $field_settings['lightbox'] ?? 0 ) && ! $is_rest ) {
 			return $link;
@@ -362,7 +362,7 @@ class GravityView_Lightbox_Entry {
 	 * @return WP_REST_Response
 	 */
 	private function process_duplicate_entry() {
-		add_filter( 'wp_redirect', '__return_false'); // Prevent redirection after the entry is duplicated.
+		add_filter( 'wp_redirect', '__return_false' ); // Prevent redirection after the entry is duplicated.
 
 		( GravityView_Duplicate_Entry::getInstance() )->process_duplicate();
 

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -398,7 +398,7 @@ class GravityView_Lightbox_Entry {
 	public function process_gravity_forms_form_submission( $response ) {
 		$rest_endpoint = $this->get_rest_endpoint_from_request();
 
-		if ( 1 === (int) ( $_REQUEST['gform_submit'] ?? 0 ) && $rest_endpoint ) {
+		if ( array_key_exists( 'gform_submit', $_REQUEST ) && $rest_endpoint ) {
 			header( 'Content-Type: text/html' );
 		}
 

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -39,6 +39,8 @@ class GravityView_Lightbox_Entry {
 		add_filter( 'gravityview_field_entry_link', [ $this, 'modify_entry_link' ], 10, 4 );
 		add_filter( 'gk/foundation/inline-scripts', [ $this, 'enqueue_view_editor_script' ] );
 		add_filter( 'gravityview/view/links/directory', [ $this, 'rewrite_directory_link' ] );
+		add_filter( 'gform_get_form_confirmation_filter', [ $this, 'process_gravity_forms_form_submission' ] );
+		add_filter( 'gform_get_form_filter', [ $this, 'process_gravity_forms_form_submission' ] );
 	}
 
 	/**
@@ -380,6 +382,27 @@ class GravityView_Lightbox_Entry {
 			200,
 			[ 'Content-Type' => 'text/html' ]
 		);
+	}
+
+	/**
+	 * Sets headers for Gravity Forms form submissions.
+	 *
+	 * @used-by `gform_get_form_confirmation_filter` filter.
+	 *
+	 * @since   TBD
+	 *
+	 * @param string $response The form submission response.
+	 *
+	 * @return string
+	 */
+	public function process_gravity_forms_form_submission( $response ) {
+		$rest_endpoint = $this->get_rest_endpoint_from_request();
+
+		if ( 1 === (int) ( $_REQUEST['gform_submit'] ?? 0 ) && $rest_endpoint ) {
+			header( 'Content-Type: text/html' );
+		}
+
+		return $response;
 	}
 
 	/**

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -3,6 +3,7 @@
 use GV\Edit_Entry_Renderer;
 use GV\Entry_Renderer;
 use GV\GF_Entry;
+use GV\Template_Context;
 use GV\View;
 
 class GravityView_Lightbox_Entry {
@@ -35,12 +36,36 @@ class GravityView_Lightbox_Entry {
 	public function __construct() {
 		require_once 'class-gravityview-lightbox-entry-request.php';
 
+		add_filter( 'gravityview/template/before', [ $this, 'maybe_enable_lightbox' ] );
 		add_filter( 'gk/foundation/rest/routes', [ $this, 'register_rest_routes' ] );
 		add_filter( 'gravityview_field_entry_link', [ $this, 'rewrite_entry_link' ], 10, 4 );
 		add_filter( 'gk/foundation/inline-scripts', [ $this, 'enqueue_view_editor_script' ] );
 		add_filter( 'gravityview/view/links/directory', [ $this, 'rewrite_directory_link' ] );
 		add_filter( 'gform_get_form_confirmation_filter', [ $this, 'process_gravity_forms_form_submission' ] );
 		add_filter( 'gform_get_form_filter', [ $this, 'process_gravity_forms_form_submission' ] );
+	}
+
+	/**
+	 * Enables lightbox when it's not explicitly enabled in the View settings but a field is configured to use it.
+	 *
+	 * @since TBD
+	 *
+	 * @param Template_Context $context
+	 *
+	 * @return void
+	 */
+	public function maybe_enable_lightbox( $context ) {
+		if ( $context->view->settings->get( 'lightbox' ) ) {
+			return;
+		}
+
+		foreach ( $context->view->fields->all() as $field ) {
+			if ( (int) ( $field->as_configuration()['lightbox'] ?? 0 ) ) {
+				$context->view->settings->set( 'lightbox', 1 );
+
+				break;
+			}
+		}
 	}
 
 	/**

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -100,7 +100,7 @@ class GravityView_Lightbox_Entry {
 	}
 
 	/**
-	 * Modify attributes for the Single or Edit Entry link in order to open inside a lightbox.
+	 * Modifies Single or Edit Entry links to open inside lightbox.
 	 *
 	 * @used-by `gravityview_field_entry_link` filter.
 	 *
@@ -149,9 +149,16 @@ class GravityView_Lightbox_Entry {
 			'data-fancybox' => $view->getCurrentField()['UID'],
 		];
 
+		if ( in_array( $field_settings['id'], [ 'edit_link', 'entry_link' ] ) ) {
+			$link_text = $is_edit ? $field_settings['edit_link'] : $field_settings['entry_link_text'];
+		} else {
+			// This sets the text for entry values that link to the Single Entry.
+			$link_text = preg_match( '/<a[^>]*>(.*?)<\/a>/', $link, $matches ) ? $matches[1] : '';
+		}
+
 		return gravityview_get_link(
 			$href,
-			$is_edit ? $field_settings['edit_link'] : $field_settings['entry_link_text'],
+			$link_text,
 			$is_rest ? [] : $atts // Do not add the attributes if the link is being rendered in the REST context.
 		);
 	}
@@ -250,7 +257,7 @@ class GravityView_Lightbox_Entry {
 	 * @param GF_Entry $entry The entry data.
 	 * @param array    $form  The form data.
 	 *
-	 * @return void
+	 * @return WP_REST_Response
 	 */
 	private function render_entry( $type, $view, $entry, $form ) {
 		add_filter( 'gravityview_go_back_url', '__return_false' );
@@ -281,26 +288,26 @@ class GravityView_Lightbox_Entry {
 
 		?>
 		<html lang="<?php echo get_bloginfo( 'language' ); ?>">
-		<head>
-			<title><?php echo $title; ?></title>
+			<head>
+				<title><?php echo $title; ?></title>
 
-			<?php wp_head(); ?>
+				<?php wp_head(); ?>
 
-			<style>
-				<?php echo $view->settings->get( 'custom_css', '' ); ?>
-			</style>
+				<style>
+					<?php echo $view->settings->get( 'custom_css', '' ); ?>
+				</style>
 
-			<script type="text/javascript">
-				<?php echo $view->settings->get( 'custom_javascript', '' ); ?>
-			</script>
-		</head>
+				<script type="text/javascript">
+					<?php echo $view->settings->get( 'custom_javascript', '' ); ?>
+				</script>
+			</head>
 
-		<body>
-			<?php echo $content; ?>
-		</body>
+			<body>
+				<?php echo $content; ?>
+			</body>
 
-		<?php wp_print_scripts(); ?>
-		<?php wp_print_styles(); ?>
+			<?php wp_print_scripts(); ?>
+			<?php wp_print_styles(); ?>
 		</html>
 		<?php
 
@@ -392,7 +399,7 @@ class GravityView_Lightbox_Entry {
 							.off( 'change.lightboxEntry' );
 					} );
 				} );
-JS,
+			JS,
 			'deps'   => [ 'jquery' ],
 		];
 

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -328,7 +328,7 @@ class GravityView_Lightbox_Entry {
 	 *
 	 * @return string
 	 */
-	public function get_rest_endpoint( int $view_id, int $entry_id ) {
+	public function get_rest_endpoint( $view_id, $entry_id ) {
 		return self::REST_NAMESPACE . "/view/{$view_id}/entry/{$entry_id}";
 	}
 

--- a/includes/extensions/lightbox/fancybox/class-gravityview-lightbox-provider-fancybox.php
+++ b/includes/extensions/lightbox/fancybox/class-gravityview-lightbox-provider-fancybox.php
@@ -119,6 +119,7 @@ class GravityView_Lightbox_Provider_FancyBox extends GravityView_Lightbox_Provid
 		$atts['data-caption']          = null;
 		$atts['data-options']          = null;
 		$atts['data-filter']           = null;
+		$atts['data-preload']          = null;
 
 		return $atts;
 	}

--- a/includes/fields/class-gravityview-field-edit-link.php
+++ b/includes/fields/class-gravityview-field-edit-link.php
@@ -55,6 +55,7 @@ class GravityView_Field_Edit_Link extends GravityView_Field {
 			'merge_tags' => true,
 		);
 
+		$this->add_field_support( 'lightbox', $field_options );
 		$this->add_field_support( 'new_window', $field_options );
 
 		return array_merge( $add_option, $field_options );

--- a/includes/fields/class-gravityview-field-entry-link.php
+++ b/includes/fields/class-gravityview-field-entry-link.php
@@ -82,6 +82,7 @@ class GravityView_Field_Entry_Link extends GravityView_Field {
 			'merge_tags' => true,
 		);
 
+		$this->add_field_support( 'lightbox', $field_options );
 		$this->add_field_support( 'new_window', $field_options );
 
 		return $add_options + $field_options;

--- a/includes/fields/class-gravityview-field.php
+++ b/includes/fields/class-gravityview-field.php
@@ -502,6 +502,13 @@ abstract class GravityView_Field {
 				'group'    => 'display',
 				'priority' => 1300,
 			),
+			'lightbox' => array(
+				'type' => 'checkbox',
+				'label' => __( 'Open in a lightbox?', 'gravityview' ),
+				'value' => false,
+				'group' => 'display',
+				'priority' => 1300,
+			),
 		);
 
 		/**

--- a/includes/fields/class-gravityview-field.php
+++ b/includes/fields/class-gravityview-field.php
@@ -504,7 +504,7 @@ abstract class GravityView_Field {
 			),
 			'lightbox' => array(
 				'type' => 'checkbox',
-				'label' => __( 'Open in a lightbox?', 'gravityview' ),
+				'label' => __( 'Open in a lightbox?', 'gk-gravityview' ),
 				'value' => false,
 				'group' => 'display',
 				'priority' => 1300,

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
+* Added: Ability to view and edit entries inside a lightbox.
 * Added: `:human` merge tag modifier for date fields to display in human-readable format (e.g., `10 minutes ago`, `5 days from now`).
 * Fixed: Clearing search removed all URL query parameters and under some circumstances redirected to the homepage.
 * Fixed: Searching the View added duplicate search parameters to the URL.

--- a/templates/fields/field-edit_link-html.php
+++ b/templates/fields/field-edit_link-html.php
@@ -46,4 +46,14 @@ $output = apply_filters( 'gravityview_entry_link', GravityView_API::replace_vari
 
 $href = GravityView_Edit_Entry::get_edit_link( $entry, $gravityview->view->ID, $post ? $post->ID : null );
 
-echo gravityview_get_link( $href, $output, $link_atts );
+$output = gravityview_get_link( $href, $output, $link_atts );
+
+/**
+ * Modify the link HTML (here for backward compatibility).
+ *
+ * @param string $output HTML output of the link
+ * @param string $href URL of the link
+ * @param array  $entry The GF entry array
+ * @param  array $field_settings Settings for the particular GV field
+ */
+echo apply_filters( 'gravityview_field_entry_link', $output, $href, $entry, $field_settings );


### PR DESCRIPTION
_(work was initially done in https://github.com/GravityKit/GravityView/pull/2055)_

## To enable:

1. Add a "Link to Single Entry" field
2. Open field settings
3. Check the "Open in a lightbox?" checkbox
4. Save the View

![](https://i.gravitykit.com/i/LVnBFN+)

## Big things to work on:

- [x] Allow for Next/Previous and Single Entry navigation options.
- [x] Remove the `<— Go back` link
- [x] Remove single entry widget header hooks `add_action( 'gravityview/template/before', array( $this, 'render_widget_hooks' ) );` (started work here: `class-gv-request-rest.php` `Request::is_entry()`)
- [x] When "open in lightbox" is enabled, disable "open in new window" option.
- [x] Make sure to embed Custom CSS and Custom JS output.
- [x] Enable galleries inside modal.
- [x] Prevent lightbox links from being indexed.
- [x] Edit Entry isn't working.
- [ ] Add support for the CSS styles that are in Dashboard Views.

## Questions form #197 

* How do we handle updating data? When closing the lightbox, if an entry has been edited, outdated values may be shown.
* Will Inline Edit work inside this? 🤯
  - If enabled, should we disable Inline Edit?

## To test:

- [x] **Single Entry link**
  - [x] The link does not open in a lightbox when the corresponding field option is not checked.
  - [x] When "Open in a lightbox?" option is checked, the link opens in a lightbox, allowing navigation left/right between entries.
  - [x] Edit Entry link opens inside the Single Entry lightbox view.
- [x] **Edit Entry link**
  - [x] The link does not open in a lightbox when the corresponding field option is not checked.
  - [x] When "open in lightbox" is checked, the link opens in a lightbox, allowing navigation left/right between entries.
  - [x] Updating the entry works.
    - [x] After an update, "return to entry" opens the Single Entry layout inside the lightbox. If it has an Edit Entry link, it should open inside the lightbox.
  - [x] Deleting the entry works.
    - [x] After deletion, the page should refresh or, if configured in the View Editor under Delete Entry, URL redirection should work.
- [x] **Permissions**: only authorized users should be able to view, edit and delete entries.

💾 [Build file](https://www.dropbox.com/scl/fi/fdp5fvj9zm2usa8hmysik/gravityview-2.28.0-49301e324.zip?rlkey=xdty6oork78qputtuqm57bllq&dl=1) (49301e324).