### PR TITLE
Fix embedded views in other fields

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1627,7 +1627,8 @@ function gravityview_field_output( $passed_args, $context = null ) {
 		return '';
 	}
 
-	if ( '' !== $placeholders['value'] && ! empty( $args['wpautop'] ) && (isset($field['id']) && $field['id'] !== 'gravityview_view') ) {
+	$field_id = GV\Utils::get( $field, 'id' );
+	if ( '' !== $placeholders['value'] && ! empty( $args['wpautop'] ) && ( $field_id !== 'gravityview_view' ) ) {
 		$placeholders['value'] = wpautop( $placeholders['value'] );
 	}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1627,7 +1627,7 @@ function gravityview_field_output( $passed_args, $context = null ) {
 		return '';
 	}
 
-	if ( '' !== $placeholders['value'] && ! empty( $args['wpautop'] ) ) {
+	if ( '' !== $placeholders['value'] && ! empty( $args['wpautop'] ) && (isset($field['id']) && $field['id'] !== 'gravityview_view') ) {
 		$placeholders['value'] = wpautop( $placeholders['value'] );
 	}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1627,8 +1627,7 @@ function gravityview_field_output( $passed_args, $context = null ) {
 		return '';
 	}
 
-	$field_id = GV\Utils::get( $field, 'id' );
-	if ( '' !== $placeholders['value'] && ! empty( $args['wpautop'] ) && ( $field_id !== 'gravityview_view' ) ) {
+	if ( '' !== $placeholders['value'] && ! empty( $args['wpautop'] ) && 'gravityview_view' !== ( $field['id'] ?? '' ) ) {
 		$placeholders['value'] = wpautop( $placeholders['value'] );
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * Fixed: Clearing search removed all URL query parameters and under some circumstances redirected to the homepage.
 * Fixed: Searching the View added duplicate search parameters to the URL.
 * Fixed: PHP 8.2 deprecation notice related to dynamic property creation.
+* Fixed: Entries not displaying when a DataTables View is embedded in a Single Entry page using the List layout.
 
 = 2.28.0 on August 29, 2024 =
 


### PR DESCRIPTION
- Fixes https://github.com/GravityKit/GravityView/issues/2090
- The wpautop function breaks the scripts from Datatables, So I disabled them for all gv views fields in this area

💾 [Build file](https://www.dropbox.com/scl/fi/iwvs16imny6ao0sp0apf2/gravityview-2.28.0-03f043413.zip?rlkey=a1k6wa56fxkovhjvoicpxebw3&dl=1) (03f043413).