### PR TITLE
Fix failing tests

### DIFF
--- a/tests/unit-tests/GVCommon_Common_Test.php
+++ b/tests/unit-tests/GVCommon_Common_Test.php
@@ -116,7 +116,7 @@ class GVCommon_Test extends GV_UnitTestCase {
 		$entry = $this->factory->entry->create_and_get( array(
 			'form_id' => $form['id'],
 			'10' 	  => $two_days_from_now,
-			'11'	  =>$two_hours_from_now
+			'11'	  => $two_hours_from_now
 		) );
 
 		$date_created = \GV\Utils::get( $entry, 'date_created' );
@@ -131,10 +131,7 @@ class GVCommon_Test extends GV_UnitTestCase {
 		$entry_local_time = GFCommon::get_local_timestamp( $entry_gmt_time );
 
 		$datepicker_gmt_time   = mysql2date( 'G', $datepicker );
-		$datepicker_local_time = GFCommon::get_local_timestamp( $datepicker_gmt_time );
-
 		$time_gmt_time   = mysql2date( 'G', $time );
-		$time_local_time = GFCommon::get_local_timestamp( $time_gmt_time );
 
 		$tests = array(
 			GVCommon::format_date( $date_created, 'raw=1') => $date_created,
@@ -169,8 +166,8 @@ class GVCommon_Test extends GV_UnitTestCase {
 			GVCommon::format_date( $date_created, array('diff' => 1, 'format' => '%s is so long ago' ) ) => sprintf( '%s is so long ago', human_time_diff( $entry_gmt_time ) ),
 
 			// 2 days and 2 hours from now
-			GVCommon::format_date( $datepicker, 'diff=1&human=1') => sprintf( '%s from now', human_time_diff( $datepicker_local_time ) ),
-			GVCommon::format_date( $time, 'diff=1&human=1&time=1') => sprintf( '%s from now', human_time_diff( $time_local_time ) ),
+			GVCommon::format_date( $datepicker, 'diff=1&human=1') => sprintf( '%s from now', human_time_diff( $datepicker_gmt_time ) ),
+			GVCommon::format_date( $time, 'diff=1&human=1&time=1') => sprintf( '%s from now', human_time_diff( $time_gmt_time ) ),
 
 			// Relative should NOT process other modifiers
 			GVCommon::format_date( $date_created, 'diff=1&time=1' ) => sprintf( '%s ago', human_time_diff( $entry_gmt_time ) ),


### PR DESCRIPTION
- Fixes  https://github.com/GravityKit/GravityView/issues/2152
- Fixed tests that might fail because of timezones
- The issue was that i was using `GFCommon::get_local_timestamp` to convert the timestamp to the local one according to current site timezone
- Then i was comparing it using human_time_diff function which uses `time()` as the second argument by default which is just the regular timestamp not adjusted for the current site timezone

💾 [Build file](https://www.dropbox.com/scl/fi/nda4akon14625rfjeqxra/gravityview-2.28.0-7ad65298c.zip?rlkey=e0pyr0vzeu9q30v9sq1bkwwuw&dl=1) (7ad65298c).