### PR TITLE
Allow field option filtering on lightbox and new_window settings

### DIFF
--- a/includes/admin/class.render.settings.php
+++ b/includes/admin/class.render.settings.php
@@ -120,6 +120,25 @@ class GravityView_Render_Settings {
 			}
 		}
 
+		if ( 'directory' === $context && isset( $field_options['show_as_link'] ) ) {
+			$field = new class extends GravityView_Field {
+				public function __construct() {
+				}
+			};
+
+			$field->add_field_support( 'new_window', $field_options );
+			$field->add_field_support( 'lightbox', $field_options );
+
+			$field_options['lightbox'] = array_merge(
+				$field_options['lightbox'] ?? [],
+				[ 'requires' => 'show_as_link', 'priority' => 101 ]
+			);
+			$field_options['new_window'] = array_merge(
+				$field_options['new_window'] ?? [],
+				[ 'requires' => 'show_as_link', 'priority' => 102 ]
+			);
+		}
+
 		// Remove suffix ":" from the labels to standardize style. Using trim() instead of rtrim() for i18n.
 		foreach ( $field_options as $key => $field_option ) {
 			$field_options[ $key ]['label'] = trim( $field_option['label'], ':' );
@@ -152,19 +171,6 @@ class GravityView_Render_Settings {
 		 * @param int    $form_id     The form ID. {@since 2.5}
 		 */
 		$field_options = apply_filters( "gravityview_template_{$input_type}_options", $field_options, $template_id, $field_id, $context, $input_type, $form_id );
-
-		if ( 'directory' === $context && isset( $field_options['show_as_link'] ) ) {
-			$field = new class extends GravityView_Field {
-				public function __construct() {
-				}
-			};
-
-			$field->add_field_support( 'new_window', $field_options );
-			$field->add_field_support( 'lightbox', $field_options );
-
-			$field_options['lightbox']   = array_merge( $field_options['lightbox'], [ 'requires' => 'show_as_link', 'priority' => 101 ] );
-			$field_options['new_window'] = array_merge( $field_options['new_window'], [ 'requires' => 'show_as_link', 'priority' => 102 ] );
-		}
 
 		if ( $grouped ) {
 

--- a/includes/admin/class.render.settings.php
+++ b/includes/admin/class.render.settings.php
@@ -21,8 +21,14 @@ class GravityView_Render_Settings {
 	 * @since $ver$
 	 */
 	public static function register_hooks(): void {
+		// Filter is applied with priority 500 to act later in the process. It is very likely this filter will be
+		// used with default or slightly higher than default priorities. This priority makes it likely
+		// all (or most) options have been processed already.
 		add_filter( 'gk/gravityview/template/options', [ self::class, 'add_general_options' ], 500, 4 );
-		add_filter( 'gk/gravityview/template/options', [ self::class, 'maybe_sort_options' ], 900, 5 );
+
+		// Filter is applied with priority 1000 to act *very* late in the process. This gives users a wide range of
+		// priority values to work with, while making it very likely those options are still sorted properly.
+		add_filter( 'gk/gravityview/template/options', [ self::class, 'maybe_sort_options' ], 1000, 5 );
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -132,6 +132,7 @@ class GravityView_Admin {
 		include_once GRAVITYVIEW_DIR . 'includes/class-admin-approve-entries.php';
 		include_once GRAVITYVIEW_DIR . 'includes/class-gravityview-bulk-actions.php';
 
+		GravityView_Render_Settings::register_hooks();
 		/**
 		 * Triggered after all GravityView admin files are loaded.
 		 *

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+* Fixed: Some field settings could not be changed with the available filter hooks.
+
 = 2.31.1 on November 8, 2024 =
 
 This hotfix release resolves display issues with certain View layouts.

--- a/readme.txt
+++ b/readme.txt
@@ -23,11 +23,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
-* Fixed: Some field settings could not be changed with the available filter hooks.
-
 __Developer Updates:__
 
-* Added: `gk/gravityview/template/options` filter in `class.render.settings.php`.
+* Added: `gk/gravityview/template/options` filter to allow programmatically modifying Field settings in the View editor.
 
 = 2.31.1 on November 8, 2024 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 * Fixed: Some field settings could not be changed with the available filter hooks.
 
+__Developer Updates:__
+
+* Added: `gk/gravityview/template/options` filter in `class.render.settings.php`.
+
 = 2.31.1 on November 8, 2024 =
 
 This hotfix release resolves display issues with certain View layouts.


### PR DESCRIPTION
This PR moves over the field options for `lightbox` and `new_window`, so these can be disabled in some instances.

It introduces a new (fully typed ;-) ) filter hook `gk/gravityview/template/options`. This filter is applied after the existing ones, and is for more general purposes. This is the reason the attributes are limited to: the options, field type (widget | field), template ID, context, whether it is grouped, and the form ID. There are no specifics about the field itself, or its type. We already have hooks for that.

This PR also resolves an old TODO that sorts the options via this hook, and it has a bit of auto formatting.