### PR TITLE
Fixes upload buttons not showing up

### DIFF
--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -332,6 +332,12 @@ class GravityView_Edit_Entry_Render {
 
 		// File download/delete icons
 		wp_enqueue_style( 'gform_admin_icons' );
+
+		// Fixes the icons not showing up correctly in Gravity Forms 2.9+
+		if ( version_compare( GFForms::$version, '2.9', '>=' ) ) {
+			wp_add_inline_style( 'gform_theme', '.gform-icon { font-family: gform-icons-admin !important; }' );
+		}
+
 	}
 
 


### PR DESCRIPTION
- Implements https://github.com/GravityKit/GravityView/issues/2208
- The main issue was gform_basic was loaded before gform_admin_icons
- I tried to reverse the order of the enqueue but that can't be done as gform_basic is not loaded with enqueue and it caused some style issues
- So i added an override style using gform_theme which only loads when 2.5 style theme is chosen and it's only loaded also if gf is 2.9 or more

💾 [Build file](https://www.dropbox.com/scl/fi/wmntwhiitk4zqhuwds804/gravityview-2.31.1-cf9276ee2.zip?rlkey=ezexazo9lscptibi4x342kl5a&dl=1) (cf9276ee2).