### PR TITLE
Add gravityview/row-added JS-event

### DIFF
--- a/assets/js/admin-grid.js
+++ b/assets/js/admin-grid.js
@@ -64,6 +64,17 @@
 						const $row = $( result?.row );
 						$row.insertBefore( $add_row );
 
+						$( document.body ).trigger(
+							'gravityview/row-added',
+							$row,
+							{
+								type,
+								row_type,
+								zone,
+								template_id
+							}
+						);
+
 						window?.gvAdminActions?.initTooltips();
 						window?.gvAdminActions?.initDroppables( $row );
 					} ) );

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 __Developer Updates:__
 
 * Added: `gk/gravityview/template/options` filter to allow programmatically modifying Field settings in the View editor.
+* Added: `gravityview/row-added` JavaScript event when a new row is added to a Widget/Field area.
 
 = 2.31.1 on November 8, 2024 =
 


### PR DESCRIPTION
This PR adds a `gravityview/row-added` event when a new row is added to a Widget/Field area. We need this event in order to make it compatible with Multiple Forms. https://github.com/GravityKit/Multiple-Forms/pull/108

💾 [Build file](https://www.dropbox.com/scl/fi/8lbpmsunhwx9y9cnrvz32/gravityview-2.31.1-c72774b88.zip?rlkey=rypy2mjqxd3tyk9jk9i89vief&dl=1) (c72774b88).