### PR TITLE
Fix unit tests on GravityForms 2.9

### DIFF
--- a/templates/deprecated/fields/post_image.php
+++ b/templates/deprecated/fields/post_image.php
@@ -117,7 +117,7 @@ $image_meta = apply_filters(
 			'label'     => esc_attr_x( 'Caption:', 'Post Image field caption heading', 'gk-gravityview' ),
 			'value'     => $caption,
 			'tag_label' => 'span',
-			'tag_value' => GFFormsModel::is_html5_enabled() ? 'figcaption' : 'div',
+			'tag_value' => 'figcaption',
 		),
 		'description' => array(
 			'label'     => esc_attr_x( 'Description:', 'Post Image field description heading', 'gk-gravityview' ),
@@ -129,7 +129,7 @@ $image_meta = apply_filters(
 );
 
 // If HTML5 output is enabled, support the `figure` and `figcaption` tags
-$wrappertag = GFFormsModel::is_html5_enabled() ? 'figure' : 'div';
+$wrappertag = 'figure';
 
 /**
  * Whether to show labels for the image meta.

--- a/templates/fields/field-post_image-html.php
+++ b/templates/fields/field-post_image-html.php
@@ -122,7 +122,7 @@ $image_meta = apply_filters(
 			'label'     => esc_attr_x( 'Caption:', 'Post Image field caption heading', 'gk-gravityview' ),
 			'value'     => $caption,
 			'tag_label' => 'span',
-			'tag_value' => GFFormsModel::is_html5_enabled() ? 'figcaption' : 'div',
+			'tag_value' => 'figcaption',
 		),
 		'description' => array(
 			'label'     => esc_attr_x( 'Description:', 'Post Image field description heading', 'gk-gravityview' ),
@@ -134,7 +134,7 @@ $image_meta = apply_filters(
 );
 
 // If HTML5 output is enabled, support the `figure` and `figcaption` tags
-$wrappertag = GFFormsModel::is_html5_enabled() ? 'figure' : 'div';
+$wrappertag = 'figure';
 
 /**
  * Whether to show labels for the image meta.

--- a/tests/unit-tests/GravityView_Edit_Entry_Test.php
+++ b/tests/unit-tests/GravityView_Edit_Entry_Test.php
@@ -476,6 +476,11 @@ class GravityView_Edit_Entry_Test extends GV_UnitTestCase {
 	 *  and second item the render instance, and third item is the reloaded entry.
 	 */
 	private function _emulate_render( $form, $view, $entry ) {
+		// Get clean form every test.
+		if ( method_exists( GFFormDisplay::class, 'flush_cached_forms' ) ) {
+			GFFormDisplay::flush_cached_forms();
+		}
+
 		$loader = GravityView_Edit_Entry::getInstance();
 		$render = $loader->instances['render'];
 

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -4259,8 +4259,8 @@ class GVFuture_Test extends GV_UnitTestCase {
 		$this->assertEquals( strlen( implode( ', ', $expected ) ), strlen( $renderer->render( $field, $view, $form, $entry, $request ) ) );
 
 		/** Post Image */
-		$image_tag = GFFormsModel::is_html5_enabled() ? 'figure' : 'div';
-		$image_caption_tag = GFFormsModel::is_html5_enabled() ? 'figcaption' : 'div';
+		$image_tag = 'figure';
+		$image_caption_tag = 'figcaption';
 		$field = \GV\GF_Field::by_id( $form, '24' );
 		$expected = sprintf('<%1$s class="gv-image"><a class="gravityview-fancybox" href="' . $filename . '" title="&lt;script&gt;TITLE&lt;/script&gt; huh, &lt;b&gt;wut&lt;/b&gt;"><img src="' . $filename . '" alt="cap&lt;script&gt;tion&lt;/script&gt;" /></a><div class="gv-image-title"><span class="gv-image-label">Title:</span> <div class="gv-image-value">&lt;script&gt;TITLE&lt;/script&gt; huh, &lt;b&gt;wut&lt;/b&gt;</div></div><div class="gv-image-caption"><span class="gv-image-label">Caption:</span> <%2$s class="gv-image-value">cap&lt;script&gt;tion&lt;/script&gt;</%2$s></div><div class="gv-image-description"><span class="gv-image-label">Description:</span> <div class="gv-image-value">de&#039;s&lt;script&gt;tion&lt;/script&gt;</div></div></%1$s>', $image_tag, $image_caption_tag);
 		$this->assertEquals( $expected, $renderer->render( $field, $view, $form, $entry, $request ) );


### PR DESCRIPTION
Gravity Forms added a caching mechanism, and since we test multiple states in the same test, instead of separate tests with a data provider it hits this cache. This PR clears that cache for every `_emulate_render` call.

Also removed any lingering `GFFormsModel::is_html5_enabled` calls as that is deprecated; and has been returning `true` for a while now. 

💾 [Build file](https://www.dropbox.com/scl/fi/5kltisoxfdq8u44jdqkuu/gravityview-2.31.1-290e52fb9.zip?rlkey=jyk6b6dy8x3iyej7qcjpb8q26&dl=1) (290e52fb9).