### PR TITLE
Fix custom Entry slug on embedded Views (#2207)

### DIFF
--- a/future/includes/class-gv-permalinks.php
+++ b/future/includes/class-gv-permalinks.php
@@ -279,7 +279,7 @@ final class Permalinks {
 	 * @return string The slug.
 	 */
 	public function set_entry_slug( $slug, $entry_id, array $entry ): string {
-		$new_slug = trim( $this->settings->get( 'entry_slug', $slug ) );
+		$new_slug = trim( (string) $this->settings->get( 'entry_slug', $slug ) );
 		$view     = $this->get_current_view();
 
 		if ( $view && (int) $view->form->ID === (int) $entry['form_id'] ) {

--- a/future/includes/class-gv-permalinks.php
+++ b/future/includes/class-gv-permalinks.php
@@ -22,6 +22,16 @@ final class Permalinks {
 	private Plugin_Settings $settings;
 
 	/**
+	 * A memoization of the current View.
+	 *
+	 * This is used to determine the View, when rendering through a short code.
+	 *
+	 * @since $ver$
+	 * @var View|null
+	 */
+	private ?View $current_view;
+
+	/**
 	 * The default slug values.
 	 *
 	 * @since 2.29.0
@@ -170,6 +180,9 @@ final class Permalinks {
 
 		add_action( 'init', [ $this, 'maybe_update_rewrite_rules' ], 1 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'add_view_settings_scripts' ], 1500 );
+
+		add_action( 'gravityview/shortcode/before-processing', [ $this, 'capture_view' ] );
+		add_action( 'gravityview/shortcode/after-processing', [ $this, 'clear_captured_view' ] );
 	}
 
 	/**
@@ -267,7 +280,7 @@ final class Permalinks {
 	 */
 	public function set_entry_slug( $slug, $entry_id, array $entry ): string {
 		$new_slug = trim( $this->settings->get( 'entry_slug', $slug ) );
-		$view     = View::from_post( get_post() );
+		$view     = $this->get_current_view();
 
 		if ( $view && (int) $view->form->ID === (int) $entry['form_id'] ) {
 			$new_slug = trim( (string) $view->settings->get( 'single_entry_slug' ) ?: $new_slug );
@@ -295,7 +308,7 @@ final class Permalinks {
 		$is_global_entry_slug = '' !== trim( (string) $this->settings->get( 'entry_slug', '' ) );
 		$is_view_entry_slug   = false;
 
-		$view = View::from_post( get_post() );
+		$view = $this->get_current_view();
 		if ( $view ) {
 			$entry_slug         = (string) $view->settings->get( 'single_entry_slug' );
 			$is_view_entry_slug = (bool) trim( $entry_slug );
@@ -741,5 +754,44 @@ final class Permalinks {
 		];
 
 		return $scripts;
+	}
+
+	/**
+	 * Captures the current View when it is rendered through a shortcode or block.
+	 * @since $ver$
+	 * @param View|null $view The View object.
+	 */
+	public function capture_view( $view ): void {
+		/**
+		 * When viewing an entry don't render multiple views.
+		 */
+		$selected_view = (int) ( $_GET['gvid'] ?? 0 );
+		if ( $selected_view && (int) $view->ID !== $selected_view ) {
+			return;
+		}
+
+		if ( $view instanceof View ) {
+			$this->current_view = $view;
+		}
+	}
+
+	/**
+	 * Clears the captured View object.
+	 *
+	 * @since $ver$
+	 */
+	public function clear_captured_view(): void {
+		$this->current_view = null;
+	}
+
+	/**
+	 * Returns the current View.
+	 *
+	 * @since $ver$
+	 */
+	private function get_current_view(): ?View {
+		$view = $this->current_view ?? View::from_post( get_post() );
+
+		return $view instanceof View ? $view : null;
 	}
 }

--- a/future/includes/class-gv-shortcode-gravityview.php
+++ b/future/includes/class-gv-shortcode-gravityview.php
@@ -307,6 +307,14 @@ class gravityview extends \GV\Shortcode {
 			 * Just this view.
 			 */
 		} else {
+			/**
+			 * When viewing a specific View don't render the other Views.
+			 */
+			$selected_view = (int) \GV\Utils::_GET( 'gvid',0 );
+			if ( $selected_view && (int) $view->ID !== $selected_view ) {
+				return self::_return( '' );
+			}
+
 			if ( $is_reembedded ) {
 
 				// Mock the request with the actual View, not the global one

--- a/future/includes/class-gv-shortcode-gravityview.php
+++ b/future/includes/class-gv-shortcode-gravityview.php
@@ -1,6 +1,8 @@
 <?php
 namespace GV\Shortcodes;
 
+use GV\View;
+
 /** If this file is called directly, abort. */
 if ( ! defined( 'GRAVITYVIEW_DIR' ) ) {
 	die();
@@ -19,6 +21,15 @@ class gravityview extends \GV\Shortcode {
 	 * A stack of calls to track nested shortcodes.
 	 */
 	public static $callstack = array();
+
+	/**
+	 * Keeps the current View remembered.
+	 *
+	 * @since $ver$
+	 *
+	 * @var View|null
+	 */
+	private static ?View $current_view = null;
 
 	/**
 	 * Process and output the [gravityview] shortcode.
@@ -108,6 +119,7 @@ class gravityview extends \GV\Shortcode {
 		 */
 		do_action( 'gravityview/shortcode/before-processing', $view, $post );
 
+		self::$current_view = $view;
 		gravityview()->views->set( $view );
 
 		/**
@@ -186,7 +198,7 @@ class gravityview extends \GV\Shortcode {
 						'</a>'
 					);
 
-					return \GVCommon::generate_notice( '<p>' . $notice . '</p>', 'notice', array( 'delete_post' ), $view->ID );
+					return self::_return( \GVCommon::generate_notice( '<p>' . $notice . '</p>', 'notice', array( 'delete_post' ), $view->ID ) );
 				case 'no_direct_access':
 				case 'embed_only':
 				case 'not_public':
@@ -485,6 +497,19 @@ class gravityview extends \GV\Shortcode {
 	 */
 	private static function _return( $value ) {
 		array_pop( self::$callstack );
+		$view = self::$current_view;
+
+		self::$current_view = null; // Clear for future calls.
+
+		/**
+		 * @action `gravityview/shortcode/after-processing` Runs after the GV shortcode is processed.
+		 *
+		 * @since  $ver$
+		 *
+		 * @param \GV\View|null $view The View object.
+		 */
+		do_action( 'gravityview/shortcode/after-processing', $view );
+
 		return $value;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * Fixed: Custom permalinks were not used on embedded Views.
 * Fixed: When multiple Views were embedded on the same page, it would show the other Views when displaying a single entry.
 
+__Developer updates__:
+* Added `gravityview/shortcode/after-processing` action after a `[gravityview]` shortcode is finished.
+
 = 2.32 on November 21, 2024 =
 
 This release adds a new form notification option for updated entries, resolves file upload issues on the Edit Entry screen, and includes developer-focused enhancements.

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
+* Fixed: Custom permalinks were not used on embedded Views.
+* Fixed: When multiple Views were embedded on the same page, it would show the other Views when displaying a single entry.
+
 = 2.32 on November 21, 2024 =
 
 This release adds a new form notification option for updated entries, resolves file upload issues on the Edit Entry screen, and includes developer-focused enhancements.


### PR DESCRIPTION
This PR addresses #2207 

When using shortcodes, its hard to determine the correct View for its settings. This PR records the View when the shortcode is being rendered. Based on that value we can now determine the settings correctly. After the shortcode is rendered it forgets the View.

For testing, also test multiple Views on the same page with different Entry slug settings.

💾 [Build file](https://www.dropbox.com/scl/fi/k5dfjawy100618cixj3th/gravityview-2.32-6dcf3f8c1.zip?rlkey=3bpohg1sty1awb594i5yfsdo7&dl=1) (6dcf3f8c1).