### PR TITLE
Fix empty column headers in Multiple Forms mobile view #2237

### DIFF
--- a/future/includes/class-gv-template-view-table.php
+++ b/future/includes/class-gv-template-view-table.php
@@ -378,11 +378,8 @@ class View_Table_Template extends View_Template {
         );
 
 		if ( $entry->is_multi() ) {
-			if ( ! $single_entry = $entry->from_field( $field ) ) {
-				echo '<td></td>';
-				return;
-			}
-			$form = GF_Form::by_id( $field->form_id );
+			$single_entry = $entry->from_field( $field );
+			$form         = GF_Form::by_id( $field->form_id );
 		}
 
 		$renderer = new Field_Renderer();

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * Custom permalinks were not used on embedded Views.
 * When multiple Views were embedded on the same page, it would show the other Views when displaying a single entry.
 * Deprecated filter notice when both the Advanced Filter extension (version 3 or newer) and Gravity Flow are active.
+* When using the Multiple Forms extension, labels for fields with empty values no longer disappear in the mobile view.
 
 #### 💻 Developer Updates
 * Added `gravityview/template/field/csv/tick` filter to programmatically modify the checkbox "check" output in CSV.


### PR DESCRIPTION
This implements #2237.

💾 [Build file](https://www.dropbox.com/scl/fi/tpfx99xvli96oc1u0e74w/gravityview-2.32-420bd45dc.zip?rlkey=vj7ziapgx8fspkrqb7em2s4m9&dl=1) (420bd45dc).