### PR TITLE
Miscellaneous fixes

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -181,15 +181,20 @@ class GravityView_API {
 
 		if ( ! empty( $field['id'] ) ) {
 			if ( ! empty( $form ) && ! empty( $form['id'] ) ) {
-				$form_id = '-' . $form['id'];
+				$form_id = $form['id'];
 			} else {
 				// @deprecated path. Form should always be given.
 				gravityview()->log->warning( 'GravityView_View::getInstance() legacy API called' );
 				$gravityview_view = GravityView_View::getInstance();
-				$form_id          = $gravityview_view->getFormId() ? '-' . $gravityview_view->getFormId() : '';
+				$form_id          = $gravityview_view->getFormId() ? $gravityview_view->getFormId() : '';
 			}
 
-			$classes[] = 'gv-field' . $form_id . '-' . $field['id'];
+			$classes[] = 'gv-field' . ( $form_id ? '-' . $form_id : '' ) . '-' . $field['id'];
+
+			// Field is from different form, so we add an extra class.
+			if ( (int) ( $field['form_id'] ?? $form_id ) !== (int) $form_id ) {
+				$classes[] = 'gv-field-' . $field['form_id'] . '-' . $field['id'];
+			}
 		}
 
 		return esc_attr( implode( ' ', $classes ) );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -211,7 +211,8 @@ class GravityView_API {
 
 		if ( ! empty( $id ) ) {
 			if ( ! empty( $form ) && ! empty( $form['id'] ) ) {
-				$form_id = '-' . $form['id'];
+				$form_id = $field['form_id'] ?? $form['id'];
+				$form_id = '-' . $form_id;
 			} else {
 				// @deprecated path. Form should always be given.
 				gravityview()->log->warning( 'GravityView_View::getInstance() legacy API called' );

--- a/includes/class-frontend-views.php
+++ b/includes/class-frontend-views.php
@@ -926,11 +926,11 @@ class GravityView_frontend {
 		}
 
 		if ( ! empty( $args['show_only_approved'] ) ) {
-
-			$search_criteria['field_filters'][] = array(
-				'key'   => GravityView_Entry_Approval::meta_key,
-				'value' => GravityView_Entry_Approval_Status::APPROVED,
-			);
+			$search_criteria['field_filters'][] = [
+				'key'      => GravityView_Entry_Approval::meta_key,
+				'operator' => '=',
+				'value'    => GravityView_Entry_Approval_Status::APPROVED,
+			];
 
 			$search_criteria['field_filters']['mode'] = 'all'; // force all the criterias to be met
 


### PR DESCRIPTION
This PR addresses some minor things. I didn't want to push to `develop` as we are about to release. But if this is agreeable, please merge. 

There is a fix for the `is_approved` condition. That currently uses a `LIKE` which is the default comparator. This is somewhat slow compared to `=`, and it is prone to future errors where a status of `11` would become a thing for example as that would then also match. In addition, multiple forms already uses `=` for the joined forms. It's just the original that doesn't. 

Furthermore I updated the calculation of the field ID, as the can cause duplicates on the page when multiple forms are joined. Fields from other forms will still have the original form ID in the `id` attribute, which can cause duplicates if another field with that ID exists. So I swap it out with the correct form ID. 

The same is done for the class name, but in order to prevent BC compatibility on styling, it is ADDED instead of replaced. For the ID this could be technically Backwards Incompatible; but practically there shouldn't be two identical IDs, so that is already a problem.

💾 [Build file](https://www.dropbox.com/scl/fi/938n1f1z3ambbsk6tp6yi/gravityview-2.32-5b9dc54c4.zip?rlkey=bvlh1dopn86232hgwhko56njo&dl=1) (5b9dc54c4).