### PR TITLE
Release 2.33.1

### DIFF
--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.33
+ * Version:             2.33.1
  * Requires PHP:        7.4.0
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
@@ -32,7 +32,7 @@ if ( ! GravityKit\GravityView\Foundation\meets_min_php_version_requirement( __FI
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.33' );
+define( 'GV_PLUGIN_VERSION', '2.33.1' );
 
 /**
  * Full path to the GravityView file

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -296,6 +296,16 @@ class GravityView_Welcome {
 				 *  - If 4.28, include to 4.26.
 				 */
 				?>
+				<h3>2.33.1 on December 30, 2024</h3>
+
+				<p>This update fixes an issue with entry notes being displayed.</p>
+
+				<h4>🐛 Fixed</h4>
+
+				<ul>
+					<li>Entry notes being displayed.</li>
+				</ul>
+
 				<h3>2.33 on December 19, 2024</h3>
 
 				<p>This release introduces support for the Source ID meta (Gravity Forms 2.9+), adds a new User Activation field to the View editor, and includes various fixes and enhancements.</p>

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -298,12 +298,12 @@ class GravityView_Welcome {
 				?>
 				<h3>2.33.1 on December 30, 2024</h3>
 
-				<p>This update fixes an issue with entry notes being displayed.</p>
+				<p>This update removes debugging code from the Entry Notes field.</p>
 
 				<h4>🐛 Fixed</h4>
 
 				<ul>
-					<li>Entry notes being displayed.</li>
+					<li>Debugging code being shown in the Entry Notes field output.</li>
 				</ul>
 
 				<h3>2.33 on December 19, 2024</h3>

--- a/includes/extensions/entry-notes/class-gravityview-field-notes.php
+++ b/includes/extensions/entry-notes/class-gravityview-field-notes.php
@@ -535,7 +535,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 			'{row_class}'   => 'gv-note',
 			'{note_detail}' => $note_detail_html,
 		);
-var_dump($note_row);exit;
+
 		// Strip extra whitespace in template
 		$output = gravityview_strip_whitespace( $note_row );
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,10 +23,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = 2.33.1 on December 30, 2024 =
 
-This update fixes an issue with entry notes being displayed.
+This update removes debugging code from the Entry Notes field.
 
 #### 🐛 Fixed
-* Entry notes being displayed.
+* Debugging code being shown in the Entry Notes field output.
 
 = 2.33 on December 19, 2024 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,13 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= 2.33.1 on December 30, 2024 =
+
+This update fixes an issue with entry notes being displayed.
+
+#### 🐛 Fixed
+* Entry notes being displayed.
+
 = 2.33 on December 19, 2024 =
 
 This release introduces support for the Source ID meta (Gravity Forms 2.9+), adds a new User Activation field to the View editor, and includes various fixes and enhancements.


### PR DESCRIPTION
This update fixes an issue with entry notes being displayed.

#### 🐛 Fixed
* Entry notes being displayed.


💾 [Build file](https://www.dropbox.com/scl/fi/e1nufgxdgi3m9dmdfezua/gravityview-2.33.1-d00ac1269.zip?rlkey=poxjxe8z6htcyy7289y3j1qys&dl=1) (d00ac1269).