### PR TITLE
Do not apply site's timezone offset to Date fields

### DIFF
--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -226,6 +226,11 @@ class GravityView_Merge_Tags {
 		}
 
 		if ( $field instanceof GF_Field_Date ) {
+			if ( false === strpos( $modifier, 'no_tz_offset' ) ) {
+				$modifier = 'no_tz_offset:' . $modifier;
+			}
+
+			// Skip the timezone offset.
 			return self::format_date( $raw_value, $modifier );
 		}
 

--- a/includes/fields/class-gravityview-field-date.php
+++ b/includes/fields/class-gravityview-field-date.php
@@ -64,6 +64,11 @@ class GravityView_Field_Date extends GravityView_Field {
 				return $return;
 			}
 
+			// Skip the timezone offset.
+			if ( false === strpos( $modifier, 'no_tz_offset' ) ) {
+				$modifier = 'no_tz_offset:' . $modifier;
+			}
+
 			$return = GravityView_Merge_Tags::format_date( $raw_value, $modifier );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 #### 🐛 Fixed
 * Fatal error when searching entries by Approval Status in Views joined with another form using the Multiple Forms extension.
 * Some merge tag modifiers (e.g., `maxwords`) were not being processed.
+* WordPress's timezone offset was not being applied to the Date field's output when using the `:format` merge tag modifier.
 
 #### ✨ Improved
 * Entries added via the Gravity Forms API or while GravityView is inactive can now be filtered using the "Unapproved" status on the Entries page.


### PR DESCRIPTION
This implements #2257.

💾 [Build file](https://www.dropbox.com/scl/fi/dq57dduahqi1vpytsin8o/gravityview-2.33.2-66d86036f.zip?rlkey=y18o4sqkaw972uafe27jppnrm&dl=1) (66d86036f).