### PR TITLE
Release 2.34

### DIFF
--- a/future/lib/class-gamajo-template-loader.php
+++ b/future/lib/class-gamajo-template-loader.php
@@ -116,10 +116,6 @@ if ( ! class_exists( '\GV\Gamajo_Template_Loader' ) ) {
 			// Get files names of templates, for given slug and name.
 			$templates = $this->get_template_file_names( $slug, $name );
 
-			if ( $slug == 'note' ) {
-				$load = false;
-			}
-
 			// Return the part that is found.
 			return $this->locate_template( $templates, $load, false );
 		}

--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.33.2
+ * Version:             2.34
  * Requires PHP:        7.4.0
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
@@ -32,7 +32,7 @@ if ( ! GravityKit\GravityView\Foundation\meets_min_php_version_requirement( __FI
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.33.2' );
+define( 'GV_PLUGIN_VERSION', '2.34' );
 
 /**
  * Full path to the GravityView file

--- a/includes/class-admin-approve-entries.php
+++ b/includes/class-admin-approve-entries.php
@@ -97,9 +97,14 @@ class GravityView_Admin_ApproveEntries {
 		);
 
 		$field_filters_unapproved = array(
+			'mode' => 'any',
 			array(
 				'key'   => GravityView_Entry_Approval::meta_key,
 				'value' => GravityView_Entry_Approval_Status::UNAPPROVED,
+			),
+			array(
+				'key'      => GravityView_Entry_Approval::meta_key,
+				'value'    => '',
 			),
 		);
 

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -296,6 +296,31 @@ class GravityView_Welcome {
 				 *  - If 4.28, include to 4.26.
 				 */
 				?>
+				<h3>2.34 on January 9, 2025</h3>
+
+				<p>This release introduces the <a href="https://www.gravitykit.com/announcing-gravityview-2-4-all-new-layout-builder/">Layout Builder</a> that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.</p>
+
+				<h4>🚀 Added</h4>
+
+				<ul>
+					<li>New Layout Builder View type for creating custom layouts with single or multi-column configurations and adjustable widths.</li>
+					<li>Support for using entry Approval Status in conditional logic rules on the Gravity Forms Export Entries page.</li>
+				</ul>
+
+				<h4>✨ Improved</h4>
+
+				<ul>
+					<li>Entries added via the Gravity Forms API or while GravityView is inactive can now be filtered using the "Unapproved" status on the Entries page.</li>
+				</ul>
+
+				<h4>🐛 Fixed</h4>
+
+				<ul>
+					<li>Fatal error when searching entries by Approval Status in Views joined with another form using the Multiple Forms extension.</li>
+					<li>Some merge tag modifiers (e.g., <code>maxwords</code>) not being processed.</li>
+					<li>WordPress's timezone offset not applying to Date field output with the <code>:format</code> merge tag modifier.</li>
+				</ul>
+
 				<h3>2.33.2 on December 31, 2024</h3>
 
 				<p>This update removes debugging code from the Entry Notes field.</p>
@@ -387,62 +412,6 @@ class GravityView_Welcome {
 					<li>Added <code>gk/gravityview/view/entries/join-conditions</code> filter to modify the join conditions applied when retrieving View entries.</li>
 					<li>Added <code>gk/gravityview/template/options</code> filter to programmatically modify field settings in the View editor.</li>
 					<li>Added <code>gravityview/row-added</code> JavaScript event, triggered when a new row is added to a widget or field area.</li>
-				</ul>
-
-				<h3>2.31.1 on November 8, 2024</h3>
-
-				<p>This hotfix release resolves display issues with certain View layouts.</p>
-
-				<h4>🐛 Fixed</h4>
-
-				<ul>
-					<li>Rendering issue affecting certain View layouts, such as Maps, introduced in the previous release.</li>
-				</ul>
-
-				<h3>2.31 on November 4, 2024</h3>
-
-				<p>This release introduces <a href="https://docs.gravitykit.com/article/1027-dynamic-widget-placement?utm_source=gravityview&utm_medium=changelog&utm_campaign=release">flexible widget positioning</a> in Views, enhances entry-in-a-lightbox functionality, and adds support for the Gravity Forms 2.9+ Image Choice field. It also addresses compatibility issues with LiteSpeed, Divi, and LifterLMS, along with various other fixes and improvements.</p>
-
-				<h4>🚀 Added</h4>
-
-				<ul>
-					<li>Ability to position widgets in the View editor using predefined layouts, offering a range of single or multi-column configurations with varying widths.</li>
-					<li>View setting to control what happens when a user clicks the Cancel link when editing an entry in the lightbox.</li>
-					<li>Support for the upcoming Image Choice field in Gravity Forms 2.9+.</li>
-				</ul>
-
-				<h4>🐛 Fixed</h4>
-
-				<ul>
-					<li>GravityView tab not displaying in certain cases under GravityKit > Settings menu.</li>
-					<li>Widgets could not be configured after being added to a new, unsaved View.</li>
-					<li>Compatibility with the Divi theme that prevented the Signature field from being edited on the Edit Entry screen.</li>
-					<li>Conflict with the LiteSpeed plugin that caused a fatal error when redirecting users after duplicating an entry.</li>
-					<li>JavaScript enqueued in the site's footer was not executed when editing an entry in the lightbox.</li>
-					<li>It was not possible to add new entry notes when viewing a single entry in the lightbox.</li>
-					<li>Validation error displayed when adding merge tags to the Entry Slug setting input in the View editor.</li>
-					<li>The search box in the Change Entry Creator field did not return results when editing an entry on the Forms > Entries screen.</li>
-					<li>Fatal error when activating LifterLMS with GravityView active.</li>
-					<li>Searching across all fields not working as expected when the search value contains special characters or accents (e.g., ä, ß, İ).</li>
-				</ul>
-
-				<h4>🔧 Updated</h4>
-
-				<ul>
-					<li><a href="https://www.gravitykit.com/foundation/">Foundation</a> to version 1.2.20.</li>
-				</ul>
-
-				<h4>💻 Developer Updates</h4>
-
-				<ul>
-					<li>Added <code>gk/gravityview/lightbox/entry/before-output</code> action that fires before the entry content is output in the lightbox.</li>
-					<li>Added <code>gk/gravityview/lightbox/entry/output/head-before</code> action that fires after the <code>&lt;head&gt;</code> tag is opened.</li>
-					<li>Added <code>gk/gravityview/lightbox/entry/output/head-after</code> action that fires before the <code>&lt;/head&gt;</code> tag is closed.</li>
-					<li>Added <code>gk/gravityview/lightbox/entry/output/content-before</code> action that fires after the <code>&lt;body&gt;</code> tag is opened and before the content is rendered.</li>
-					<li>Added <code>gk/gravityview/lightbox/entry/output/content-after</code> action that fires after the content is rendered and before the footer.</li>
-					<li>Added <code>gk/gravityview/lightbox/entry/output/footer-after</code> action that fires after the footer and before the closing <code>&lt;/body&gt;</code> tag.</li>
-					<li>Added <code>gravityview/fields/image_choice/image_markup</code> filter to modify the Image Choice field (Gravity Forms 2.9+) markup.</li>
-					<li>Added <code>gravityview/fields/image_choice/output_label</code> filter to control whether to display the value or label of an Image Choice field.</li>
 				</ul>
 
 				<p style="text-align: center;">

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -298,7 +298,7 @@ class GravityView_Welcome {
 				?>
 				<h3>2.34 on January 9, 2025</h3>
 
-				<p>This release introduces the <a href="https://www.gravitykit.com/?p=846801">Layout Builder</a> that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.</p>
+				<p>This release introduces the <a href="https://www.gravitykit.com/announcing-gravityview-2-34-all-new-layout-builder">Layout Builder</a> that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.</p>
 
 				<h4>🚀 Added</h4>
 

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -298,7 +298,7 @@ class GravityView_Welcome {
 				?>
 				<h3>2.34 on January 9, 2025</h3>
 
-				<p>This release introduces the <a href="https://www.gravitykit.com/announcing-gravityview-2-4-all-new-layout-builder/">Layout Builder</a> that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.</p>
+				<p>This release introduces the <a href="https://www.gravitykit.com/?p=846801">Layout Builder</a> that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.</p>
 
 				<h4>🚀 Added</h4>
 
@@ -317,7 +317,7 @@ class GravityView_Welcome {
 
 				<ul>
 					<li>Fatal error when searching entries by Approval Status in Views joined with another form using the Multiple Forms extension.</li>
-					<li>Some merge tag modifiers (e.g., <code>maxwords</code>) not being processed.</li>
+					li>Some <a href='https://docs.gravitykit.com/article/350-merge-tag-modifiers'>merge tag modifiers</a> (e.g., <code>:maxwords</code>) not being processed.</li>
 					<li>WordPress's timezone offset not applying to Date field output with the <code>:format</code> merge tag modifier.</li>
 				</ul>
 

--- a/includes/class-gravityview-entry-approval.php
+++ b/includes/class-gravityview-entry-approval.php
@@ -58,6 +58,44 @@ class GravityView_Entry_Approval {
 		add_action( 'gravityview/approve_entries/updated', array( $this, '_trigger_notifications' ) );
 
 		add_action( 'check_admin_referer', [ $this, 'resend_gf_notifications' ], 10, 2 );
+
+		add_filter( 'gform_field_filters', [ $this, 'add_approval_field_filter' ] );
+
+	}
+
+	/**
+	 * Adds approval status filter to the filter list (Export Entries conditional logic).
+	 *
+	 * @since TBD
+	 *
+	 * @param array $filters The existing filters.
+	 * @param array $form    The form array.
+	 *
+	 * @return array The modified filters.
+	 */
+	public function add_approval_field_filter( $filters ) {
+		$filters[] = [
+			'key'             => 'is_approved',
+			'text'            => esc_html__( 'Approval Status', 'gk-gravityview' ),
+			'preventMultiple' => false,
+			'operators'       => [ 'is' ],
+			'values'          => [
+				[
+					'value' => '1',
+					'text'  => esc_html__( 'Approved', 'gk-gravityview' ),
+				],
+				[
+					'value' => '2',
+					'text'  => esc_html__( 'Disapproved', 'gk-gravityview' ),
+				],
+				[
+					'value' => '3',
+					'text'  => esc_html__( 'Unapproved', 'gk-gravityview' ),
+				],
+			],
+		];
+
+		return $filters;
 	}
 
 	/**

--- a/includes/class-gravityview-entry-approval.php
+++ b/includes/class-gravityview-entry-approval.php
@@ -66,7 +66,7 @@ class GravityView_Entry_Approval {
 	/**
 	 * Adds approval status filter to the filter list (Export Entries conditional logic).
 	 *
-	 * @since TBD
+	 * @since 2.34
 	 *
 	 * @param array $filters The existing filters.
 	 * @param array $form    The form array.

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -85,7 +85,7 @@ class GravityView_Merge_Tags {
 	 */
 	public static function process_modifiers( $value, $merge_tag, $modifier, $field, $raw_value ) {
 		// Process array value for sub-fields like name and address.
-		if ( $raw_value[ $merge_tag ] ?? null ) {
+		if ( is_array( $raw_value ) && ( $raw_value[ $merge_tag ] ?? null ) ) {
 			$raw_value = $raw_value[ $merge_tag ];
 		}
 

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -226,6 +226,11 @@ class GravityView_Merge_Tags {
 		}
 
 		if ( $field instanceof GF_Field_Date ) {
+			if ( false === strpos( $modifier, 'no_tz_offset' ) ) {
+				$modifier = 'no_tz_offset:' . $modifier;
+			}
+
+			// Skip the timezone offset.
 			return self::format_date( $raw_value, $modifier );
 		}
 

--- a/includes/fields/class-gravityview-field-date.php
+++ b/includes/fields/class-gravityview-field-date.php
@@ -64,6 +64,11 @@ class GravityView_Field_Date extends GravityView_Field {
 				return $return;
 			}
 
+			// Skip the timezone offset.
+			if ( false === strpos( $modifier, 'no_tz_offset' ) ) {
+				$modifier = 'no_tz_offset:' . $modifier;
+			}
+
 			$return = GravityView_Merge_Tags::format_date( $raw_value, $modifier );
 		}
 

--- a/includes/presets/layout-builder/class-gravityview-layout-builder.php
+++ b/includes/presets/layout-builder/class-gravityview-layout-builder.php
@@ -158,4 +158,4 @@ final class GravityView_Layout_Builder extends GravityView_Template {
 	}
 }
 
-// new GravityView_Layout_Builder();
+new GravityView_Layout_Builder();

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -1122,12 +1122,12 @@ class GravityView_Widget_Search extends \GV\Widget {
 				if ( empty( $filter['key'] ) && $search_condition->expressions ) {
 					$search_conditions[] = $search_condition;
 				} else {
-					$left = $search_condition->left;
-
 					// If the left condition is empty, it is likely a multiple forms filter. In this case, we should retrieve the search condition from the main form.
-					if ( ! $left && $search_condition->expressions ) {
+					if ( ! $search_condition->left && $search_condition->expressions ) {
 						$search_condition = $search_condition->expressions[0];
 					}
+
+					$left = $search_condition->left;
 
 					// When casting a column value to a certain type (e.g., happens with the Number field), GF_Query_Column is wrapped in a GF_Query_Call class.
 					if ( $left instanceof GF_Query_Call && $left->parameters ) {

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -1113,12 +1113,22 @@ class GravityView_Widget_Search extends \GV\Widget {
 					)
 				);
 				$_tmp_query_parts = $_tmp_query->_introspect();
+
+				/**
+				 * @var GF_Query_Condition $search_condition
+				 * */
 				$search_condition = $_tmp_query_parts['where'];
 
 				if ( empty( $filter['key'] ) && $search_condition->expressions ) {
 					$search_conditions[] = $search_condition;
 				} else {
 					$left = $search_condition->left;
+
+					// If the left condition is empty, it is likely a multiple forms filter. In this case, we should retrieve the search condition from the main form.
+					if ( ! $left && $search_condition->expressions ) {
+						$search_condition = $search_condition->expressions[0];
+					}
+
 					// When casting a column value to a certain type (e.g., happens with the Number field), GF_Query_Column is wrapped in a GF_Query_Call class.
 					if ( $left instanceof GF_Query_Call && $left->parameters ) {
 						// Update columns to include the correct alias.
@@ -1133,7 +1143,7 @@ class GravityView_Widget_Search extends \GV\Widget {
 						}, $left->parameters );
 
 						$left = new GF_Query_Call( $left->function_name, $parameters );
-					} else {
+					} elseif ( $left ) {
 						$alias = $query->_alias( $left->field_id, $left->source, $left->is_entry_column() ? 't' : 'm' );
 						$left  = new GF_Query_Column( $left->field_id, $left->source, $alias );
 					}

--- a/readme.txt
+++ b/readme.txt
@@ -24,10 +24,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 = develop =
 
 #### 🚀 Added
-* Support for entry approval statuses in conditional logic on the Gravity Forms Export Entries page.
+* Support for using entry Approval Status in conditional logic rules on the Gravity Forms Export Entries page.
 
 #### 🐛 Fixed
-* Fatal error when searching entries by approval status in Views joined with another form using the Multiple Forms extension.
+* Fatal error when searching entries by Approval Status in Views joined with another form using the Multiple Forms extension.
 * Some merge tag modifiers (e.g., `maxwords`) were not being processed.
 
 #### ✨ Improved

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = 2.34 on January 9, 2025 =
 
-This release introduces the [Layout Builder](https://www.gravitykit.com/announcing-gravityview-2-4-all-new-layout-builder/) that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.
+This release introduces the [Layout Builder](https://www.gravitykit.com/?p=846801) that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.
 
 #### 🚀 Added
 * New Layout Builder View type for creating custom layouts with single or multi-column configurations and adjustable widths.
@@ -34,7 +34,7 @@ This release introduces the [Layout Builder](https://www.gravitykit.com/announci
 
 #### 🐛 Fixed
 * Fatal error when searching entries by Approval Status in Views joined with another form using the Multiple Forms extension.
-* Some merge tag modifiers (e.g., `maxwords`) not being processed.
+* Some [merge tag modifiers](https://docs.gravitykit.com/article/350-merge-tag-modifiers) (e.g., `:maxwords`) not being processed.
 * WordPress's timezone offset not applying to Date field output with the `:format` merge tag modifier.
 
 = 2.33.2 on December 31, 2024 =

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 #### 🐛 Fixed
 * Fatal error when searching entries by Approval Status in Views joined with another form using the Multiple Forms extension.
 * Some merge tag modifiers (e.g., `maxwords`) were not being processed.
+* WordPress's timezone offset was not being applied to the Date field's output when using the `:format` merge tag modifier.
 
 #### ✨ Improved
 * Entries added via the Gravity Forms API or while GravityView is inactive can now be filtered using the "Unapproved" status on the Entries page.

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = 2.34 on January 9, 2025 =
 
-This release introduces the [Layout Builder](https://www.gravitykit.com/?p=846801) that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.
+This release introduces the [Layout Builder](https://www.gravitykit.com/announcing-gravityview-2-34-all-new-layout-builder) that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.
 
 #### 🚀 Added
 * New Layout Builder View type for creating custom layouts with single or multi-column configurations and adjustable widths.

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+#### 🐛 Fixed
+* Fatal error when searching entries by approval status in Views joined with another form using the Multiple Forms extension.
+
 = 2.33.2 on December 31, 2024 =
 
 This update removes debugging code from the Entry Notes field.

--- a/readme.txt
+++ b/readme.txt
@@ -27,12 +27,14 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * Fatal error when searching entries by approval status in Views joined with another form using the Multiple Forms extension.
 * Some merge tag modifiers (e.g., `maxwords`) were not being processed.
 
+#### ✨ Improved
+* Entries added via the Gravity Forms API or while GravityView is inactive can now be filtered using the "Unapproved" status on the Entries page.
+
 = 2.33.2 on December 31, 2024 =
 
 This update removes debugging code from the Entry Notes field.
 
 #### 🐛 Fixed
-
 * Debugging code being shown in the Entry Notes field output.
 * Output of the User Activation field not being sanitized.
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,18 +21,21 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
-= develop =
+= 2.34 on January 9, 2025 =
+
+This release introduces the [Layout Builder](https://www.gravitykit.com/announcing-gravityview-2-4-all-new-layout-builder/) that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.
 
 #### 🚀 Added
+* New Layout Builder View type for creating custom layouts with single or multi-column configurations and adjustable widths.
 * Support for using entry Approval Status in conditional logic rules on the Gravity Forms Export Entries page.
-
-#### 🐛 Fixed
-* Fatal error when searching entries by Approval Status in Views joined with another form using the Multiple Forms extension.
-* Some merge tag modifiers (e.g., `maxwords`) were not being processed.
-* WordPress's timezone offset was not being applied to the Date field's output when using the `:format` merge tag modifier.
 
 #### ✨ Improved
 * Entries added via the Gravity Forms API or while GravityView is inactive can now be filtered using the "Unapproved" status on the Entries page.
+
+#### 🐛 Fixed
+* Fatal error when searching entries by Approval Status in Views joined with another form using the Multiple Forms extension.
+* Some merge tag modifiers (e.g., `maxwords`) not being processed.
+* WordPress's timezone offset not applying to Date field output with the `:format` merge tag modifier.
 
 = 2.33.2 on December 31, 2024 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
+#### 🚀 Added
+* Support for entry approval statuses in conditional logic on the Gravity Forms Export Entries page.
+
 #### 🐛 Fixed
 * Fatal error when searching entries by approval status in Views joined with another form using the Multiple Forms extension.
 * Some merge tag modifiers (e.g., `maxwords`) were not being processed.

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 #### 🐛 Fixed
 * Fatal error when searching entries by approval status in Views joined with another form using the Multiple Forms extension.
+* Some merge tag modifiers (e.g., `maxwords`) were not being processed.
 
 = 2.33.2 on December 31, 2024 =
 

--- a/tests/unit-tests/GravityView_Entry_Approval_Test.php
+++ b/tests/unit-tests/GravityView_Entry_Approval_Test.php
@@ -244,4 +244,36 @@ class GravityView_Entry_Approval_Test extends GV_UnitTestCase {
 		$this->assertFalse( GravityView_Entry_Approval::update_bulk( range( 20000, 20010 ), GravityView_Entry_Approval_Status::APPROVED, $this->form_id ), 'Should have returned false; Invalid entry IDs' );
 	}
 
+	public function test_entry_list_filter_links() {
+		// Discussion: https://gravitykit.slack.com/archives/C727B06MB/p1736354374221989
+		$this->markTestSkipped('Flaky test due to $wpdb sometimes returning empty results');
+
+		$form = $this->factory->form->create_and_get();
+
+		$entry = $this->factory->entry->create_and_get( [ 'form_id' => $form['id'] ] );
+
+		$approve_entries = new class extends GravityView_Admin_ApproveEntries { };
+
+		$filter_links = $approve_entries->filter_links_entry_list( [], $form );
+
+		$this->assertEquals( 0, $filter_links[0]['count'] );
+		$this->assertEquals( 0, $filter_links[1]['count'] );
+		$this->assertEquals( 1, $filter_links[2]['count'] );
+
+		GravityView_Entry_Approval::update_approved( $entry['id'], GravityView_Entry_Approval_Status::APPROVED, $form['id'] );
+
+		$filter_links = $approve_entries->filter_links_entry_list( [], $form );
+
+		$this->assertEquals( 1, $filter_links[0]['count'] );
+		$this->assertEquals( 0, $filter_links[1]['count'] );
+		$this->assertEquals( 0, $filter_links[2]['count'] );
+
+		GravityView_Entry_Approval::update_approved( $entry['id'], GravityView_Entry_Approval_Status::DISAPPROVED, $form['id'] );
+
+		$filter_links = $approve_entries->filter_links_entry_list( [], $form );
+
+		$this->assertEquals( 0, $filter_links[0]['count'] );
+		$this->assertEquals( 1, $filter_links[1]['count'] );
+		$this->assertEquals( 0, $filter_links[2]['count'] );
+	}
 }

--- a/tests/unit-tests/GravityView_Future_Test.php
+++ b/tests/unit-tests/GravityView_Future_Test.php
@@ -3682,7 +3682,7 @@ class GVFuture_Test extends GV_UnitTestCase {
 		$field = \GV\Internal_Field::by_id( 'notes' );
 		$field->update_configuration( array( 'notes' => array( 'view' => true ) ) );
 		$this->assertStringContainsString( 'gv-has-notes', $renderer->render( $field, $view, null, $entry, $request ) );
-		#$this->assertStringContainsString( 'this &lt;script&gt;1&lt;/script&gt; is a note :) {entry_id}', $renderer->render( $field, $view, null, $entry, $request ) );
+		$this->assertStringContainsString( 'this &lt;script&gt;1&lt;/script&gt; is a note :) {entry_id}', $renderer->render( $field, $view, null, $entry, $request ) );
 
 		$field->update_configuration( array( 'notes' => array( 'view' => true, 'add' => true ) ) );
 		#$this->assertStringContainsString( 'gv-add-note-submit', $renderer->render( $field, $view, null, $entry, $request ) );


### PR DESCRIPTION
This release introduces the [Layout Builder](https://www.gravitykit.com/announcing-gravityview-2-4-all-new-layout-builder/) that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.

#### 🚀 Added
* New Layout Builder View type for creating custom layouts with single or multi-column configurations and adjustable widths.
* Support for using entry Approval Status in conditional logic rules on the Gravity Forms Export Entries page.

#### ✨ Improved
* Entries added via the Gravity Forms API or while GravityView is inactive can now be filtered using the "Unapproved" status on the Entries page.

#### 🐛 Fixed
* Fatal error when searching entries by Approval Status in Views joined with another form using the Multiple Forms extension.
* Some merge tag modifiers (e.g., `maxwords`) not being processed.
* WordPress's timezone offset not applying to Date field output with the `:format` merge tag modifier.

💾 [Build file](https://www.dropbox.com/scl/fi/1w6a8qscw0ax371rvn2ui/gravityview-2.34-09da5d236.zip?rlkey=d8aluhhsacqqptgm8n78y93be&dl=1) (09da5d236).