### PR TITLE
Release 2.34.1

### DIFF
--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.34
+ * Version:             2.34.1
  * Requires PHP:        7.4.0
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
@@ -32,7 +32,7 @@ if ( ! GravityKit\GravityView\Foundation\meets_min_php_version_requirement( __FI
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.34' );
+define( 'GV_PLUGIN_VERSION', '2.34.1' );
 
 /**
  * Full path to the GravityView file

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -296,6 +296,27 @@ class GravityView_Welcome {
 				 *  - If 4.28, include to 4.26.
 				 */
 				?>
+				<h3>2.34.1 on January 30, 2025</h3>
+
+				<p>This update resolves multiple issues, including problems with search bar visibility in Layout Builder, entry management in multisite environments, and non-functional entry locking and notes, among others.</p>
+
+				<h4>🦛 Fixed</h4>
+
+				<ul>
+					<li>The Search Bar would not always be visible in Views using the Layout Builder.</li>
+					<li>Users belonging to the main network site in a multisite environment couldn’t delete their own entries on subsites.</li>
+					<li>Entry locking not working.</li>
+					<li>JavaScript error preventing entry notes from being added when using the Twenty Twenty-Two theme or newer.</li>
+					<li>Using a comma in the <code>:format</code> merge tag modifier with Date fields caused partial results to be returned.</li>
+				</ul>
+
+				<h4>💻 Developer Updates</h4>
+
+				<ul>
+					<li>Added <code>gk/gravityview/edit-entry/renderer/enqueue-entry-lock-assets</code> filter to override whether to load the entry lock UI assets.</li>
+					<li>Added <code>gk/gravityview/edit-entry/renderer/entry-lock-dialog-markup</code> filter to modify the entry locking UI dialog window markup.</li>
+				</ul>
+
 				<h3>2.34 on January 9, 2025</h3>
 
 				<p>This release introduces the <a href="https://www.gravitykit.com/announcing-gravityview-2-34-all-new-layout-builder">Layout Builder</a> that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.</p>
@@ -317,7 +338,7 @@ class GravityView_Welcome {
 
 				<ul>
 					<li>Fatal error when searching entries by Approval Status in Views joined with another form using the Multiple Forms extension.</li>
-					li>Some <a href='https://docs.gravitykit.com/article/350-merge-tag-modifiers'>merge tag modifiers</a> (e.g., <code>:maxwords</code>) not being processed.</li>
+					<li>Some <a href='https://docs.gravitykit.com/article/350-merge-tag-modifiers'>merge tag modifiers</a> (e.g., <code>:maxwords</code>) not being processed.</li>
 					<li>WordPress's timezone offset not applying to Date field output with the <code>:format</code> merge tag modifier.</li>
 				</ul>
 
@@ -377,41 +398,6 @@ class GravityView_Welcome {
 				<ul>
 					<li>Added <code>gravityview/template/field/csv/tick</code> filter to programmatically modify the checkbox "check" output in CSV.</li>
 					<li>Added <code>gravityview/shortcode/after-processing</code> action after a <code>[gravityview]</code> shortcode is finished.</li>
-				</ul>
-
-				<h3>2.32 on November 21, 2024</h3>
-
-				<p>This release adds a new form notification option for updated entries, resolves file upload issues on the Edit Entry screen, and includes developer-focused enhancements.</p>
-
-				<h4>🚀 Added</h4>
-
-				<ul>
-					<li>New notification option for forms, triggered when an entry is updated.</li>
-				</ul>
-
-				<h4>🐛 Fixed</h4>
-
-				<ul>
-					<li>File upload field issues on the Edit Entry screen:
-						<ul>
-							<li>Delete/download icons not displaying in Gravity Forms 2.9+;</li>
-							<li>Unable to select files for upload when the form field's "Multiple Files" setting was enabled without a "Maximum Number of Files" value.</li>
-						</ul>
-					</li>
-				</ul>
-
-				<h4>🔧 Updated</h4>
-
-				<ul>
-					<li><a href="https://www.gravitykit.com/foundation/">Foundation</a> to version 1.2.21.</li>
-				</ul>
-
-				<h4>💻 Developer Updates</h4>
-
-				<ul>
-					<li>Added <code>gk/gravityview/view/entries/join-conditions</code> filter to modify the join conditions applied when retrieving View entries.</li>
-					<li>Added <code>gk/gravityview/template/options</code> filter to programmatically modify field settings in the View editor.</li>
-					<li>Added <code>gravityview/row-added</code> JavaScript event, triggered when a new row is added to a widget or field area.</li>
 				</ul>
 
 				<p style="text-align: center;">

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -88,7 +88,7 @@ class GravityView_Cache {
 
 		add_action( 'gform_post_update_entry_property', array( $this, 'entry_property_changed' ), 10, 4 );
 
-		add_action( 'gform_delete_entry', array( $this, 'entry_property_changed' ), 10 );
+		add_action( 'gform_delete_entry', array( $this, 'entry_property_changed' ) );
 	}
 
 	/**

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -88,7 +88,7 @@ class GravityView_Cache {
 
 		add_action( 'gform_post_update_entry_property', array( $this, 'entry_property_changed' ), 10, 4 );
 
-		add_action( 'gform_delete_lead', array( $this, 'entry_property_changed' ), 10 );
+		add_action( 'gform_delete_entry', array( $this, 'entry_property_changed' ), 10 );
 	}
 
 	/**

--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -117,7 +117,13 @@ class GravityView_Merge_Tags {
 			'human'						=> 'modifier_human', /** @see modifier_human */
 		);
 
-		$modifiers = explode( ',', $modifier );
+		// Do not split on escaped commas (\,).
+		$modifiers = preg_split('/(?<!\\\\),/', $modifier);
+
+		// Remove \ from escaped commas before processing.
+		$modifiers = array_map(function($mod) {
+			return str_replace('\\,', ',', trim($mod));
+		}, $modifiers);
 
 		$return = $raw_value;
 
@@ -137,6 +143,7 @@ class GravityView_Merge_Tags {
 				if ( empty( $matches ) ) {
 					continue;
 				}
+
 
 				// The called method is passed the raw value and the full matches array
 				$return = self::$method( $return, $matches, $value, $field, $passed_modifier, $merge_tag );

--- a/includes/extensions/edit-entry/class-edit-entry-locking.php
+++ b/includes/extensions/edit-entry/class-edit-entry-locking.php
@@ -47,7 +47,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Get the lock request meta for an object.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param int $object_id The object ID.
 	 *
@@ -161,7 +161,7 @@ class GravityView_Edit_Entry_Locking {
 		 *
 		 * Filter: `gk/gravityview/edit-entry/renderer/enqueue-entry-lock-assets`
 		 *
-		 * @since TBD
+		 * @since 2.34.1
 		 *
 		 * @param bool  $load  Whether to load the entry lock UI assets. Default: false.
 		 * @param array $entry The entry.
@@ -334,7 +334,7 @@ class GravityView_Edit_Entry_Locking {
 		 *
 		 * @filter `gk/gravityview/edit-entry/renderer/entry-lock-dialog-markup`
 		 *
-		 * @since  TBD
+		 * @since  2.34.1
 		 *
 		 * @param string $html The HTML markup.
 		 */
@@ -419,7 +419,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Checks if this entry is locked to some other user.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param int $entry_id The entry ID.
 	 *
@@ -438,7 +438,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Check if the current user has a lock request for an object.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param int $object_id The object ID.
 	 *
@@ -457,7 +457,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Returns the lock status by leveraging GF's persistent caching mechanism.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param int $entry_id The entry ID.
 	 *
@@ -470,7 +470,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Sets the lock for an entry.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param int $entry_id The entry ID.
 	 * @param int $user_id  The user ID to lock the entry to.
@@ -484,7 +484,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Returns the cache key used to retrieve/save the lock status for an entry.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param int $entry_id
 	 *
@@ -497,7 +497,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Releases the lock for an entry.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param int $entry_id The entry ID.
 	 *
@@ -535,7 +535,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Checks if the objects are locked.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param array $response The response array.
 	 * @param array $data     The data array.
@@ -571,7 +571,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Refreshes the lock for an entry.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param array $response The response array.
 	 * @param array $data     The data array.
@@ -631,7 +631,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Requests the lock for an entry.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param array  $response  The response array.
 	 * @param array  $data      The data array.
@@ -672,7 +672,7 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Refreshes nonces for an entry.
 	 *
-	 * @since TBD
+	 * @since 2.34.1
 	 *
 	 * @param array $response The response array.
 	 * @param array $data     The data array.

--- a/includes/extensions/edit-entry/class-edit-entry-locking.php
+++ b/includes/extensions/edit-entry/class-edit-entry-locking.php
@@ -1,6 +1,10 @@
 <?php
 
 /** If this file is called directly, abort. */
+
+use GV\Utils;
+use GV\View_Collection;
+
 if ( ! defined( 'GRAVITYVIEW_DIR' ) ) {
 	die();
 }
@@ -11,43 +15,64 @@ if ( ! defined( 'GRAVITYVIEW_DIR' ) ) {
  * @since 2.5.2
  */
 class GravityView_Edit_Entry_Locking {
+	const LOCK_CACHE_KEY_PREFIX = 'lock_entry_';
 
 	/**
 	 * Load extension entry point.
 	 *
 	 * DO NOT RENAME this method. Required by the class-edit-entry.php component loader.
 	 *
-	 * @see GravityView_Edit_Entry::load_components()
-	 *
 	 * @since 2.5.2
+	 *
+	 * @see   GravityView_Edit_Entry::load_components()
 	 *
 	 * @return void
 	 */
 	public function load() {
-		if ( ! has_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_scripts' ) ) ) {
-			add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_scripts' ) );
+		if ( ! has_action( 'wp_enqueue_scripts', [ $this, 'maybe_enqueue_scripts' ] ) ) {
+			add_action( 'wp_enqueue_scripts', [ $this, 'maybe_enqueue_scripts' ] );
 		}
 
-		add_action( 'wp_ajax_gf_lock_request_entry', array( $this, 'ajax_lock_request' ), 1 );
-		add_action( 'wp_ajax_gf_reject_lock_request_entry', array( $this, 'ajax_reject_lock_request' ), 1 );
-		add_action( 'wp_ajax_nopriv_gf_lock_request_entry', array( $this, 'ajax_lock_request' ) );
-		add_action( 'wp_ajax_nopriv_gf_reject_lock_request_entry', array( $this, 'ajax_reject_lock_request' ) );
+		add_filter( 'heartbeat_received', [ $this, 'heartbeat_refresh_nonces' ], 10, 2 );
+		add_filter( 'heartbeat_received', [ $this, 'heartbeat_check_locked_objects' ], 10, 2 );
+		add_filter( 'heartbeat_received', [ $this, 'heartbeat_refresh_lock' ], 10, 2 );
+		add_filter( 'heartbeat_received', [ $this, 'heartbeat_request_lock' ], 10, 2 );
+
+		add_action( 'wp_ajax_gf_lock_request_entry', [ $this, 'ajax_lock_request' ], 1 );
+		add_action( 'wp_ajax_gf_reject_lock_request_entry', [ $this, 'ajax_reject_lock_request' ], 1 );
+		add_action( 'wp_ajax_nopriv_gf_lock_request_entry', [ $this, 'ajax_lock_request' ] );
+		add_action( 'wp_ajax_nopriv_gf_reject_lock_request_entry', [ $this, 'ajax_reject_lock_request' ] );
+	}
+
+	/**
+	 * Get the lock request meta for an object.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $object_id The object ID.
+	 *
+	 * @return int|null The User ID or null.
+	 */
+	protected function get_lock_request_meta( $object_id ) {
+		return GFCache::get( 'lock_request_entry_' . $object_id );
 	}
 
 	// TODO: Convert to extending Gravity Forms
 	public function ajax_lock_request() {
 		$object_id = rgget( 'object_id' );
-		$response  = $this->request_lock( $object_id );
-		echo json_encode( $response );
-		die();
+
+		$response = $this->request_lock( $object_id );
+
+		wp_send_json( $response );
 	}
 
 	// TODO: Convert to extending Gravity Forms
 	public function ajax_reject_lock_request() {
 		$object_id = rgget( 'object_id' );
-		$response  = $this->delete_lock_request_meta( $object_id );
-		echo json_encode( $response );
-		die();
+
+		$response = $this->delete_lock_request_meta( $object_id );
+
+		wp_send_json( $response );
 	}
 
 	// TODO: Convert to extending Gravity Forms
@@ -65,28 +90,42 @@ class GravityView_Edit_Entry_Locking {
 
 		$lock_holder_user_id = $this->check_lock( $object_id );
 
-		$result = array();
+		$result = [];
+
 		if ( ! $lock_holder_user_id ) {
 			$this->set_lock( $object_id );
+
 			$result['html']   = __( 'You now have control', 'gk-gravityview' );
 			$result['status'] = 'lock_obtained';
-		} else {
 
-			if ( GVCommon::has_cap( 'gravityforms_edit_entries' ) ) {
-				$user           = get_userdata( $lock_holder_user_id );
-				$result['html'] = sprintf( __( 'Your request has been sent to %s.', 'gk-gravityview' ), $user->display_name );
-			} else {
-				$result['html'] = __( 'Your request has been sent.', 'gk-gravityview' );
-			}
-
-			$this->update_lock_request_meta( $object_id, $user_id );
-
-			$result['status'] = 'lock_requested';
+			return $result;
 		}
+
+		if ( GVCommon::has_cap( 'gravityforms_edit_entries' ) ) {
+			$user = get_userdata( $lock_holder_user_id );
+
+			$result['html'] = sprintf( __( 'Your request has been sent to %s.', 'gk-gravityview' ), $user->display_name );
+		} else {
+			$result['html'] = __( 'Your request has been sent.', 'gk-gravityview' );
+		}
+
+		$this->update_lock_request_meta( $object_id, $user_id );
+
+		$result['status'] = 'lock_requested';
 
 		return $result;
 	}
 
+	/**
+	 * Updates the lock request meta for an object.
+	 *
+	 * @since 2.34
+	 *
+	 * @param string $object_id
+	 * @param string $lock_request_value
+	 *
+	 * @return void
+	 */
 	protected function update_lock_request_meta( $object_id, $lock_request_value ) {
 		GFCache::set( 'lock_request_entry_' . $object_id, $lock_request_value, true, 120 );
 	}
@@ -97,6 +136,8 @@ class GravityView_Edit_Entry_Locking {
 	 * - Is it Edit Entry?
 	 * - Is the entry connected to a View that has `edit_locking` enabled?
 	 * - Is the entry connected to a form connected to a currently-loaded View?
+	 * - Does the user have the capability to edit the entry?
+	 * - Is the nonce valid?
 	 *
 	 * @internal
 	 * @since 2.7
@@ -112,47 +153,59 @@ class GravityView_Edit_Entry_Locking {
 			return;
 		}
 
+		$entry = $entry->as_entry();
+
+		/**
+		 * Overrides whether to load the entry lock UI assets.
+		 * This filter runs before checking whether if the edit entry link is valid, user has the capability to edit the entry, etc.
+		 *
+		 * Filter: `gk/gravityview/edit-entry/renderer/enqueue-entry-lock-assets`
+		 *
+		 * @since TBD
+		 *
+		 * @param bool  $load  Whether to load the entry lock UI assets. Default: false.
+		 * @param array $entry The entry.
+		 */
+		if ( apply_filters( 'gk/gravityview/edit-entry/renderer/enqueue-entry-lock-assets', false, $entry ) ) {
+			$this->enqueue_scripts( $entry );
+		}
+
 		if ( ! $post || ! is_a( $post, 'WP_Post' ) ) {
 			return;
 		}
 
-		$views = \GV\View_Collection::from_post( $post );
+		$views = View_Collection::from_post( $post );
 
-		$entry_array = $entry->as_entry();
-
-		$continue_enqueuing = false;
-
-		// If any Views being loaded have entry locking, enqueue the scripts
+		// If any Views being loaded have entry locking, enqueue the scripts.
 		foreach ( $views->all() as $view ) {
-
 			// Make sure the View has edit locking enabled
 			if ( ! $view->settings->get( 'edit_locking' ) ) {
 				continue;
 			}
 
-			// Make sure that the entry belongs to one of the forms connected to one of the Views in this request
-			$joined_forms = $view::get_joined_forms( $view->ID );
-
-			$entry_form_id = $entry_array['form_id'];
-
-			if ( ! isset( $joined_forms[ $entry_form_id ] ) ) {
+			// Make sure that the entry belongs to the View form.
+			if ( $view->form->ID !== (int) $entry['form_id'] ) {
 				continue;
 			}
 
-			$continue_enqueuing = true;
+			// Check user capabilities.
+			if ( ! GravityView_Edit_Entry::check_user_cap_edit_entry( $entry, $view ) ) {
+				continue;
+			}
+
+			// Check the nonce.
+			if ( ! ( new GravityView_Edit_Entry_Render( GravityView_Edit_Entry::getInstance() ) )->verify_nonce() ) {
+				continue;
+			}
+
+			$this->enqueue_scripts( $entry );
 
 			break;
 		}
-
-		if ( ! $continue_enqueuing ) {
-			return;
-		}
-
-		$this->enqueue_scripts( $entry_array );
 	}
 
 	/**
-	 * Enqueue the required scripts and styles from Gravity Forms.
+	 * Enqueues the required scripts and styles from Gravity Forms.
 	 *
 	 * Called via load() and `wp_enqueue_scripts`
 	 *
@@ -163,33 +216,52 @@ class GravityView_Edit_Entry_Locking {
 	 * @return void
 	 */
 	protected function enqueue_scripts( $entry ) {
+		$lock_user_id = $this->check_lock( $entry['id'] );
+
+		// Gravity forms locking checks if #wpwrap exist in the admin dashboard, 
+		// So we have to add the lock UI to the body before the gforms locking script is loaded.
+		wp_add_inline_script( 'heartbeat', '
+			jQuery(document).ready(function($) {
+				if ($("#wpwrap").length === 0) {
+					var lockUI = ' . json_encode( $this->get_lock_ui( $lock_user_id, $entry ) ) . ';
+					$("body").prepend(lockUI);
+				}
+			});
+		' );
 
 		$min          = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG || isset( $_GET['gform_debug'] ) ? '' : '.min';
 		$locking_path = GFCommon::get_base_url() . '/includes/locking/';
 
-		wp_enqueue_script( 'gforms_locking', $locking_path . "js/locking{$min}.js", array( 'jquery', 'heartbeat' ), GFCommon::$version );
-		wp_enqueue_style( 'gforms_locking_css', $locking_path . "css/locking{$min}.css", array( 'edit' ), GFCommon::$version );
+		wp_enqueue_script( 'gforms_locking', $locking_path . "js/locking{$min}.js", [ 'jquery', 'heartbeat' ], GFCommon::$version );
+		wp_enqueue_style( 'gforms_locking_css', $locking_path . "css/locking{$min}.css", [ 'edit' ], GFCommon::$version );
+
+		// add inline css to hide notification-dialog-wrap if it has the hidden class
+		wp_add_inline_style( 'gforms_locking_css', '
+			.notification-dialog-wrap.hidden {
+				display: none;
+			}
+		' );
 
 		$translations = array_map( 'wp_strip_all_tags', $this->get_strings() );
 
-		$strings = array(
+		$strings = [
 			'noResponse'    => $translations['no_response'],
 			'requestAgain'  => $translations['request_again'],
 			'requestError'  => $translations['request_error'],
 			'gainedControl' => $translations['gained_control'],
 			'rejected'      => $translations['request_rejected'],
 			'pending'       => $translations['request_pending'],
-		);
+		];
 
 		$lock_user_id = $this->check_lock( $entry['id'] );
 
-		$vars = array(
+		$vars = [
 			'hasLock'    => ! $lock_user_id ? 1 : 0,
-			'lockUI'     => $this->get_lock_ui( $lock_user_id ),
+			'lockUI'     => $this->get_lock_ui( $lock_user_id, $entry ),
 			'objectID'   => $entry['id'],
 			'objectType' => 'entry',
 			'strings'    => $strings,
-		);
+		];
 
 		wp_localize_script( 'gforms_locking', 'gflockingVars', $vars );
 	}
@@ -197,26 +269,27 @@ class GravityView_Edit_Entry_Locking {
 	/**
 	 * Returns a string with the Lock UI HTML markup.
 	 *
-	 * Called script enqueuing, added to JavaScript gforms_locking global variable.
+	 * Called script enqueuing, added to JavaScript `gforms_locking` global variable.
 	 *
 	 * @since 2.5.2
 	 *
-	 * @see GravityView_Edit_Entry_Locking::check_lock
+	 * @see   GravityView_Edit_Entry_Locking::check_lock
 	 *
-	 * @param int $user_id The User ID that has the current lock. Will be empty if entry is not locked
-	 *                     or is locked to the current user.
+	 * @param int   $user_id The User ID that has the current lock. Will be empty if entry is not locked
+	 *                       or is locked to the current user.
+	 * @param array $entry   The entry array.
 	 *
 	 * @return string The Lock UI dialog box, etc.
 	 */
-	public function get_lock_ui( $user_id ) {
+	public function get_lock_ui( $user_id, $entry ) {
 		$user = get_userdata( $user_id );
 
 		$locked = $user_id && $user;
 
 		$hidden = $locked ? '' : ' hidden';
-		if ( $locked ) {
 
-			if ( GVCommon::has_cap( 'gravityforms_edit_entries' ) ) {
+		if ( $locked ) {
+			if ( GVCommon::has_cap( 'gravityforms_edit_entries' ) || $entry['created_by'] == get_current_user_id() ) {
 				$avatar              = get_avatar( $user->ID, 64 );
 				$person_editing_text = $user->display_name;
 			} else {
@@ -229,7 +302,6 @@ class GravityView_Edit_Entry_Locking {
                             <div class="gform-locked-avatar">' . $avatar . '</div>
                             <p class="currently-editing" tabindex="0">' . esc_html( sprintf( $this->get_string( 'currently_locked' ), $person_editing_text ) ) . '</p>
                             <p>
-
                                 <a id="gform-take-over-button" style="display:none" class="button button-primary wp-tab-first" href="' . esc_url( add_query_arg( 'get-edit-lock', '1' ) ) . '">' . esc_html__( 'Take Over', 'gk-gravityview' ) . '</a>
                                 <button id="gform-lock-request-button" class="button button-primary wp-tab-last">' . esc_html__( 'Request Control', 'gk-gravityview' ) . '</button>
                                 <a class="button" onclick="history.back(-1); return false;">' . esc_html( $this->get_string( 'cancel' ) ) . '</a>
@@ -238,9 +310,7 @@ class GravityView_Edit_Entry_Locking {
                                 <!-- placeholder -->
                             </div>
                         </div>';
-
 		} else {
-
 			$message = '<div class="gform-taken-over">
                             <div class="gform-locked-avatar"></div>
                             <p class="wp-tab-first" tabindex="0">
@@ -253,28 +323,33 @@ class GravityView_Edit_Entry_Locking {
                         </div>';
 
 		}
-		$html  = '<div id="gform-lock-dialog" class="notification-dialog-wrap' . $hidden . '">
+
+		$html = '<div id="gform-lock-dialog" class="notification-dialog-wrap' . $hidden . '">
                     <div class="notification-dialog-background"></div>
-                    <div class="notification-dialog">';
-		$html .= $message;
+                    <div class="notification-dialog">' . $message . '</div>';
+		$html .= '</div>';
 
-		$html .= '   </div>
-                 </div>';
-
-		return $html;
+		/**
+		 * Modifies the edit entry lock UI markup.
+		 *
+		 * @filter `gk/gravityview/edit-entry/renderer/entry-lock-dialog-markup`
+		 *
+		 * @since  TBD
+		 *
+		 * @param string $html The HTML markup.
+		 */
+		return apply_filters( 'gk/gravityview/edit-entry/renderer/entry-lock-dialog-markup', $html );
 	}
 
 	/**
-	 * Localized string for the UI.
-	 *
-	 * Uses gravityforms textdomain unchanged.
+	 * Returns localized text strings used in the UI.
 	 *
 	 * @since 2.5.2
 	 *
 	 * @return array An array of translations.
 	 */
 	public function get_strings() {
-		$translations = array(
+		$translations = [
 			'currently_locked'  => __( 'This entry is currently locked. Click on the "Request Control" button to let %s know you\'d like to take over.', 'gk-gravityview' ),
 			'currently_editing' => __( '%s is currently editing this entry', 'gk-gravityview' ),
 			'taken_over'        => __( '%s has taken over and is currently editing this entry.', 'gk-gravityview' ),
@@ -287,7 +362,7 @@ class GravityView_Edit_Entry_Locking {
 			'request_again'     => __( 'Request again', 'gk-gravityview' ),
 			'request_error'     => __( 'Error', 'gk-gravityview' ),
 			'request_rejected'  => __( 'Your request was rejected', 'gk-gravityview' ),
-		);
+		];
 
 		$translations = array_map( 'wp_strip_all_tags', $translations );
 
@@ -295,105 +370,145 @@ class GravityView_Edit_Entry_Locking {
 	}
 
 	/**
-	 * Get a localized string.
+	 * Returns a localized string.
 	 *
 	 * @param string $string The string to get.
 	 *
 	 * @return string A localized string. See self::get_strings()
 	 */
 	public function get_string( $string ) {
-		return \GV\Utils::get( $this->get_strings(), $string, '' );
+		return Utils::get( $this->get_strings(), $string, '' );
 	}
 
 	/**
-	 * Lock the entry... maybe.
+	 * Locks the entry... maybe.
 	 *
 	 * Has 3 modes of locking:
-	 *
 	 *  - acquire (get), which reloads the page after locking the entry
 	 *  - release, which reloads the page after unlocking the entry
 	 *  - default action to lock on load if not locked
+	 *
+	 * @since 2.34
 	 *
 	 * @param int $entry_id The entry ID.
 	 *
 	 * @return void
 	 */
 	public function maybe_lock_object( $entry_id ) {
-		global $wp;
-
-		$current_url = add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
+		$current_url = home_url( add_query_arg( null, null ) );
 
 		if ( isset( $_GET['get-edit-lock'] ) ) {
 			$this->set_lock( $entry_id );
+
 			echo '<script>window.location = ' . json_encode( remove_query_arg( 'get-edit-lock', $current_url ) ) . ';</script>';
+
 			exit();
 		} elseif ( isset( $_GET['release-edit-lock'] ) ) {
 			$this->delete_lock_meta( $entry_id );
+
 			$current_url = remove_query_arg( 'edit', $current_url );
+
 			echo '<script>window.location = ' . json_encode( remove_query_arg( 'release-edit-lock', $current_url ) ) . ';</script>';
+
 			exit();
-		} elseif ( ! $user_id = $this->check_lock( $entry_id ) ) {
-				$this->set_lock( $entry_id );
+		} elseif ( ! $this->check_lock( $entry_id ) ) {
+			$this->set_lock( $entry_id );
 		}
 	}
 
 	/**
-	 * Is this entry locked to some other user?
+	 * Checks if this entry is locked to some other user.
+	 *
+	 * @since TBD
 	 *
 	 * @param int $entry_id The entry ID.
 	 *
 	 * @return boolean Yes or no.
 	 */
 	public function check_lock( $entry_id ) {
-		if ( ! $user_id = $this->get_lock_meta( $entry_id ) ) {
+		$user_id = $this->get_lock_meta( $entry_id );
+
+		if ( ! $user_id || $user_id == get_current_user_id() ) {
 			return false;
 		}
 
-		if ( $user_id != get_current_user_id() ) {
-			return $user_id;
-		}
-
-		return false;
+		return $user_id;
 	}
 
 	/**
-	 * The lock for an entry.
+	 * Check if the current user has a lock request for an object.
 	 *
-	 * Leverages Gravity Forms' persistent caching mechanisms.
+	 * @since TBD
+	 *
+	 * @param int $object_id The object ID.
+	 *
+	 * @return int|false The User ID or false.
+	 */
+	protected function check_lock_request( $object_id ) {
+		$user_id = (int) $this->get_lock_request_meta( $object_id );
+
+		if ( ! $user_id || $user_id === get_current_user_id() ) {
+			return false;
+		}
+
+		return $user_id;
+	}
+
+	/**
+	 * Returns the lock status by leveraging GF's persistent caching mechanism.
+	 *
+	 * @since TBD
 	 *
 	 * @param int $entry_id The entry ID.
 	 *
 	 * @return int|null The User ID or null.
 	 */
 	public function get_lock_meta( $entry_id ) {
-		return GFCache::get( 'lock_entry_' . $entry_id );
+		return GFCache::get( $this->get_lock_cache_key_for_entry( $entry_id ) );
 	}
 
 	/**
-	 * Set the lock for an entry.
+	 * Sets the lock for an entry.
+	 *
+	 * @since TBD
 	 *
 	 * @param int $entry_id The entry ID.
-	 * @param int $user_id The user ID to lock the entry to.
+	 * @param int $user_id  The user ID to lock the entry to.
 	 *
 	 * @return void
 	 */
 	public function update_lock_meta( $entry_id, $user_id ) {
-		GFCache::set( 'lock_entry_' . $entry_id, $user_id, true, 1500 );
+		GFCache::set( $this->get_lock_cache_key_for_entry( $entry_id ), $user_id, true, 1500 );
 	}
 
 	/**
-	 * Release the lock for an entry.
+	 * Returns the cache key used to retrieve/save the lock status for an entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $entry_id
+	 *
+	 * @return string
+	 */
+	public function get_lock_cache_key_for_entry( $entry_id ) {
+		return self::LOCK_CACHE_KEY_PREFIX . $entry_id;
+	}
+
+	/**
+	 * Releases the lock for an entry.
+	 *
+	 * @since TBD
 	 *
 	 * @param int $entry_id The entry ID.
 	 *
 	 * @return void
 	 */
 	public function delete_lock_meta( $entry_id ) {
-		GFCache::delete( 'lock_entry_' . $entry_id );
+		GFCache::delete( $this->get_lock_cache_key_for_entry( $entry_id ) );
 	}
 
 	/**
-	 * Lock the entry to the current user.
+	 * Locks the entry to the current user.
 	 *
 	 * @since 2.5.2
 	 *
@@ -402,7 +517,6 @@ class GravityView_Edit_Entry_Locking {
 	 * @return int|false Locked or not.
 	 */
 	public function set_lock( $entry_id ) {
-
 		$entry = GFAPI::get_entry( $entry_id );
 
 		if ( ! GravityView_Edit_Entry::check_user_cap_edit_entry( $entry ) ) {
@@ -416,5 +530,183 @@ class GravityView_Edit_Entry_Locking {
 		$this->update_lock_meta( $entry_id, $user_id );
 
 		return $user_id;
+	}
+
+	/**
+	 * Checks if the objects are locked.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $response The response array.
+	 * @param array $data     The data array.
+	 *
+	 * @return array The response array.
+	 */
+	public function heartbeat_check_locked_objects( $response, $data ) {
+		$checked = [];
+
+		$heartbeat_key = 'gform-check-locked-objects-entry';
+
+		if ( array_key_exists( $heartbeat_key, $data ) && is_array( $data[ $heartbeat_key ] ) ) {
+			foreach ( $data[ $heartbeat_key ] as $object_id ) {
+				if ( ( $user_id = $this->check_lock( $object_id ) ) && ( $user = get_userdata( $user_id ) ) ) {
+					$send = [ 'text' => sprintf( __( $this->get_string( 'currently_editing' ) ), $user->display_name ) ];
+
+					if ( ( $avatar = get_avatar( $user->ID, 18 ) ) && preg_match( "|src='([^']+)'|", $avatar, $matches ) ) {
+						$send['avatar_src'] = $matches[1];
+					}
+
+					$checked[ $object_id ] = $send;
+				}
+			}
+		}
+
+		if ( ! empty( $checked ) ) {
+			$response[ $heartbeat_key ] = $checked;
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Refreshes the lock for an entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $response The response array.
+	 * @param array $data     The data array.
+	 *
+	 * @return array The response array.
+	 */
+	public function heartbeat_refresh_lock( $response, $data ) {
+		$heartbeat_key = 'gform-refresh-lock-entry';
+
+		if ( array_key_exists( $heartbeat_key, $data ) ) {
+			$received = $data[ $heartbeat_key ];
+
+			$send = [];
+
+			if ( ! isset( $received['objectID'] ) ) {
+				return $response;
+			}
+
+			$object_id = $received['objectID'];
+
+			if ( ( $user_id = $this->check_lock( $object_id ) ) && ( $user = get_userdata( $user_id ) ) ) {
+				$error = [
+					'text' => sprintf( __( $this->get_string( 'taken_over' ) ), $user->display_name ),
+				];
+
+				$avatar = get_avatar( $user->ID, 64 );
+
+				if ( $avatar && preg_match( "|src='([^']+)'|", $avatar, $matches ) ) {
+					$error['avatar_src'] = $matches[1];
+				}
+
+				$send['lock_error'] = $error;
+			} elseif ( $new_lock = $this->set_lock( $object_id ) ) {
+				$send['new_lock'] = $new_lock;
+
+				if ( ( $lock_requester = $this->check_lock_request( $object_id ) ) && ( $user = get_userdata( $lock_requester ) ) ) {
+					$lock_request = [
+						'text' => sprintf( __( $this->get_string( 'lock_requested' ) ), $user->display_name ),
+					];
+
+					$avatar = get_avatar( $user->ID, 64 );
+
+					if ( $avatar && preg_match( "|src='([^']+)'|", $avatar, $matches ) ) {
+						$lock_request['avatar_src'] = $matches[1];
+					}
+
+					$send['lock_request'] = $lock_request;
+				}
+			}
+
+			$response[ $heartbeat_key ] = $send;
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Requests the lock for an entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param array  $response  The response array.
+	 * @param array  $data      The data array.
+	 * @param string $screen_id The screen ID.
+	 *
+	 * @return array The response array.
+	 */
+	public function heartbeat_request_lock( $response, $data ) {
+		$heartbeat_key = 'gform-request-lock-entry';
+
+		if ( ! array_key_exists( $heartbeat_key, $data ) ) {
+			return $response;
+		}
+
+		$received = $data[ $heartbeat_key ];
+
+		$send = [];
+
+		if ( ! isset( $received['objectID'] ) ) {
+			return $response;
+		}
+
+		$object_id = $received['objectID'];
+
+		$user_id = $this->check_lock( $object_id );
+
+		if ( $user_id && get_userdata( $user_id ) ) {
+			$send['status'] = $this->get_lock_request_meta( $object_id ) ? 'pending' : 'deleted';
+		} elseif ( $this->set_lock( $object_id ) ) {
+			$send['status'] = 'granted';
+		}
+
+		$response[ $heartbeat_key ] = $send;
+
+		return $response;
+	}
+
+	/**
+	 * Refreshes nonces for an entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $response The response array.
+	 * @param array $data     The data array.
+	 *
+	 * @return array The response array.
+	 */
+	public function heartbeat_refresh_nonces( $response, $data ) {
+		if ( ! array_key_exists( 'gform-refresh-nonces', $data ) ) {
+			return $response;
+		}
+
+		$received = $data['gform-refresh-nonces'];
+
+		$response['gform-refresh-nonces'] = [ 'check' => 1 ];
+
+		if ( ! isset( $received['objectID'] ) ) {
+			return $response;
+		}
+
+		$object_id = $received['objectID'];
+
+		if ( ! GVCommon::has_cap( 'gravityforms_edit_entries' ) || empty( $received['post_nonce'] ) ) {
+			return $response;
+		}
+
+		if ( 2 === wp_verify_nonce( $received['object_nonce'], 'update-contact_' . $object_id ) ) {
+			$response['gform-refresh-nonces'] = [
+				'replace'        => [
+					'_wpnonce' => wp_create_nonce( 'update-object_' . $object_id ),
+				],
+				'heartbeatNonce' => wp_create_nonce( 'heartbeat-nonce' ),
+			];
+		}
+
+		return $response;
 	}
 }

--- a/includes/extensions/edit-entry/class-edit-entry.php
+++ b/includes/extensions/edit-entry/class-edit-entry.php
@@ -352,7 +352,7 @@ class GravityView_Edit_Entry {
     /**
      * checks if user has permissions to edit a specific entry
      *
-     * Needs to be used combined with GravityView_Edit_Entry::user_can_edit_entry for maximum security!!
+     * Needs to be used combined with GravityView_Edit_Entry_Render::user_can_edit_entry for maximum security!!
      *
      * @param  array|\WP_Error $entry Gravity Forms entry array or WP_Error if the entry wasn't found.
      * @param \GV\View|int    $view ID of the view you want to check visibility against {@since 1.9.2}. Required since 2.0.
@@ -403,7 +403,7 @@ class GravityView_Edit_Entry {
             $current_user = wp_get_current_user();
 
             // User edit is disabled
-            if ( empty( $user_edit ) ) {
+            if ( $view_id && empty( $user_edit ) ) {
 
                 gravityview()->log->debug( 'User Edit is disabled. Returning false.' );
 

--- a/includes/extensions/entry-notes/class-gravityview-field-notes.php
+++ b/includes/extensions/entry-notes/class-gravityview-field-notes.php
@@ -2,9 +2,9 @@
 /**
  * Notes Field
  *
- * @package     GravityView
- * @license     GPL2+
  * @since       1.17
+ * @license     GPL2+
+ * @package     GravityView
  * @author      Katz Web Services, Inc.
  * @link        https://www.gravitykit.com
  * @copyright   Copyright 2016, Katz Web Services, Inc.
@@ -16,28 +16,29 @@
  * @since 1.17
  */
 class GravityView_Field_Notes extends GravityView_Field {
+	const ASSETS_HANDLE = 'gravityview-notes';
 
 	/**
-	 * @var string Current __FILE__
 	 * @since 1.17
+	 * @var string Current __FILE__
 	 */
 	static $file;
 
 	/**
-	 * @var string plugin_dir_path() of the current field file
 	 * @since 1.17
+	 * @var string plugin_dir_path() of the current field file
 	 */
 	static $path;
 
 	/**
-	 * @var bool Are we doing an AJAX request?
 	 * @since 1.17
+	 * @var bool Are we doing an AJAX request?
 	 */
 	private $doing_ajax = false;
 
 	/**
 	 * The name of the GravityView field type
-     *
+	 *
 	 * @var string
 	 */
 	var $name = 'notes';
@@ -65,56 +66,55 @@ class GravityView_Field_Notes extends GravityView_Field {
 	 */
 	private function add_hooks() {
 
-		add_shortcode( 'gv_note_add', array( 'GravityView_Field_Notes', 'get_add_note_part' ) );
+		add_shortcode( 'gv_note_add', [ 'GravityView_Field_Notes', 'get_add_note_part' ] );
 
-		add_action( 'wp', array( $this, 'maybe_delete_notes' ), 1000 );
-		add_action( 'wp_ajax_nopriv_gv_delete_notes', array( $this, 'maybe_delete_notes' ) );
-		add_action( 'wp_ajax_gv_delete_notes', array( $this, 'maybe_delete_notes' ) );
+		add_action( 'wp', [ $this, 'maybe_delete_notes' ], 1000 );
+		add_action( 'wp_ajax_nopriv_gv_delete_notes', [ $this, 'maybe_delete_notes' ] );
+		add_action( 'wp_ajax_gv_delete_notes', [ $this, 'maybe_delete_notes' ] );
 
-		add_action( 'wp', array( $this, 'maybe_add_note' ), 1000 );
-		add_action( 'wp_ajax_nopriv_gv_note_add', array( $this, 'maybe_add_note' ) );
-		add_action( 'wp_ajax_gv_note_add', array( $this, 'maybe_add_note' ) );
+		add_action( 'wp', [ $this, 'maybe_add_note' ], 1000 );
+		add_action( 'wp_ajax_nopriv_gv_note_add', [ $this, 'maybe_add_note' ] );
+		add_action( 'wp_ajax_gv_note_add', [ $this, 'maybe_add_note' ] );
 
 		// add template path to check for field
-		add_filter( 'gravityview_template_paths', array( $this, 'add_template_path' ) );
-		add_filter( 'gravityview/template/fields_template_paths', array( $this, 'add_template_path' ) );
+		add_filter( 'gravityview_template_paths', [ $this, 'add_template_path' ] );
+		add_filter( 'gravityview/template/fields_template_paths', [ $this, 'add_template_path' ] );
 
-		add_action( 'wp_enqueue_scripts', array( $this, 'register_scripts' ) );
-		add_action( 'gravityview/field/notes/scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'gravityview/field/notes/scripts', [ $this, 'enqueue_scripts' ] );
 
-		add_filter( 'gravityview_entry_default_fields', array( $this, 'add_entry_default_field' ), 10, 3 );
+		add_filter( 'gravityview_entry_default_fields', [ $this, 'add_entry_default_field' ], 10, 3 );
 	}
 
 
 	/**
 	 * Add Entry Notes to the Add Field picker in Edit View
 	 *
-	 * @see GravityView_Admin_Views::get_entry_default_fields()
-	 *
 	 * @since 1.17
 	 *
+	 * @see   GravityView_Admin_Views::get_entry_default_fields()
+	 *
 	 * @param array  $entry_default_fields Fields configured to show in the picker
-	 * @param array  $form Gravity Forms form array
-	 * @param string $zone Current context: `directory`, `single`, `edit`
+	 * @param array  $form                 Gravity Forms form array
+	 * @param string $zone                 Current context: `directory`, `single`, `edit`
 	 *
 	 * @return array Fields array with notes added, if in Multiple Entries or Single Entry context
 	 */
 	public function add_entry_default_field( $entry_default_fields, $form, $zone ) {
 
-		if ( in_array( $zone, array( 'directory', 'single' ) ) ) {
-			$entry_default_fields['notes'] = array(
+		if ( in_array( $zone, [ 'directory', 'single' ] ) ) {
+			$entry_default_fields['notes'] = [
 				'label' => __( 'Entry Notes', 'gk-gravityview' ),
 				'type'  => 'notes',
 				'desc'  => __( 'Display, add, and delete notes for an entry.', 'gk-gravityview' ),
 				'icon'  => 'dashicons-admin-comments',
-			);
+			];
 		}
 
 		return $entry_default_fields;
 	}
 
 	/**
-	 * Register scripts and styles used by the Notes field
+	 * Registers scripts and styles used in the UI.
 	 *
 	 * @since 1.17
 	 *
@@ -122,44 +122,46 @@ class GravityView_Field_Notes extends GravityView_Field {
 	 */
 	public function register_scripts() {
 		$css_file = gravityview_css_url( 'entry-notes.css', self::$path . 'assets/css/' );
-		wp_register_style( 'gravityview-notes', $css_file, array(), GV_PLUGIN_VERSION );
-		wp_register_script( 'gravityview-notes', plugins_url( '/assets/js/entry-notes.js', self::$file ), array( 'jquery' ), GV_PLUGIN_VERSION, true );
+
+		wp_register_style( self::ASSETS_HANDLE, $css_file, [], GV_PLUGIN_VERSION );
+		wp_register_script( self::ASSETS_HANDLE, plugins_url( '/assets/js/entry-notes.js', self::$file ), [ 'jquery' ], GV_PLUGIN_VERSION, true );
 	}
 
 	/**
-	 * Enqueue, localize field scripts and styles
+	 * Enqueues and localizes scripts and styles.
 	 *
 	 * @since 1.17
 	 *
 	 * @return void
 	 */
 	public function enqueue_scripts() {
-		global $wp_actions;
-
-		if ( ! wp_script_is( 'gravityview-notes', 'enqueued' ) ) {
-			wp_enqueue_style( 'gravityview-notes' );
-			wp_enqueue_script( 'gravityview-notes' );
+		if ( wp_script_is( self::ASSETS_HANDLE ) ) {
+			return;
 		}
 
-		if ( ! wp_script_is( 'gravityview-notes', 'done' ) ) {
-
-			$strings = self::strings();
-
-			wp_localize_script(
-                'gravityview-notes',
-                'GVNotes',
-                array(
-					'ajaxurl' => admin_url( 'admin-ajax.php' ),
-					'text'    => array(
-						'processing'       => $strings['processing'],
-						'delete_confirm'   => $strings['delete-confirm'],
-						'note_added'       => $strings['added-note'],
-						'error_invalid'    => $strings['error-invalid'],
-						'error_empty_note' => $strings['error-empty-note'],
-					),
-                )
-            );
+		if ( ! wp_script_is( self::ASSETS_HANDLE, 'registered' ) ) {
+			$this->register_scripts();
 		}
+
+		$strings = self::strings();
+
+		wp_localize_script(
+			self::ASSETS_HANDLE,
+			'GVNotes',
+			[
+				'ajaxurl' => admin_url( 'admin-ajax.php' ),
+				'text'    => [
+					'processing'       => $strings['processing'],
+					'delete_confirm'   => $strings['delete-confirm'],
+					'note_added'       => $strings['added-note'],
+					'error_invalid'    => $strings['error-invalid'],
+					'error_empty_note' => $strings['error-empty-note'],
+				],
+			]
+		);
+
+		wp_enqueue_style( self::ASSETS_HANDLE );
+		wp_enqueue_script( self::ASSETS_HANDLE );
 	}
 
 	/**
@@ -167,7 +169,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 	 *
 	 * @since 1.17
 	 *
-	 * @see process_add_note
+	 * @see   process_add_note
 	 *
 	 * @return void
 	 */
@@ -200,16 +202,16 @@ class GravityView_Field_Notes extends GravityView_Field {
 	 *
 	 * @since 1.17
 	 *
-	 * @var array $data {
-	 *  @type string $action "gv_note_add"
-	 *  @type string $entry-slug Entry slug or ID to add note to
-	 *  @type string $gv_note_add Nonce with action "gv_note_add_{entry slug}" and name "gv_note_add"
-	 *  @type string $_wp_http_referer Relative URL to submitting page ('/view/example/entry/123/')
-	 *  @type string $gv-note-content Note content
-	 *  @type string $add_note Submit button value ('Add Note')
-	 * }
-	 *
 	 * @return void
+	 * @var array   $data             {
+	 * @type string $action           "gv_note_add"
+	 * @type string $entry            -slug Entry slug or ID to add note to
+	 * @type string $gv_note_add      Nonce with action "gv_note_add_{entry slug}" and name "gv_note_add"
+	 * @type string $_wp_http_referer Relative URL to submitting page ('/view/example/entry/123/')
+	 * @type string $gv               -note-content Note content
+	 * @type string $add_note         Submit button value ('Add Note')
+	 *                                }
+	 *
 	 */
 	private function process_add_note( $data ) {
 
@@ -251,10 +253,10 @@ class GravityView_Field_Notes extends GravityView_Field {
 
 					if ( $note ) {
 						$success = self::display_note( $note, ! empty( $data['show-delete'] ) );
-						gravityview()->log->debug( 'The note was successfully created', array( 'data' => compact( 'note', 'data' ) ) );
+						gravityview()->log->debug( 'The note was successfully created', [ 'data' => compact( 'note', 'data' ) ] );
 					} else {
 						$error = self::strings( 'error-add-note' );
-						gravityview()->log->error( 'The note was not successfully created', array( 'data' => compact( 'note', 'data' ) ) );
+						gravityview()->log->error( 'The note was not successfully created', [ 'data' => compact( 'note', 'data' ) ] );
 					}
 				}
 			} else {
@@ -265,10 +267,10 @@ class GravityView_Field_Notes extends GravityView_Field {
 
 		if ( $this->doing_ajax ) {
 			if ( $success ) {
-				wp_send_json_success( array( 'html' => $success ) );
+				wp_send_json_success( [ 'html' => $success ] );
 			} else {
 				$error = $error ? $error : self::strings( 'error-invalid' );
-				wp_send_json_error( array( 'error' => esc_html( $error ) ) );
+				wp_send_json_error( [ 'error' => esc_html( $error ) ] );
 			}
 		}
 	}
@@ -278,9 +280,9 @@ class GravityView_Field_Notes extends GravityView_Field {
 	 *
 	 * Verify permissions. Check expected $_POST. Parse args, then send to process_delete_notes
 	 *
-  	 * @since 1.17
+	 * @since 1.17
 	 *
-	 * @see process_delete_notes
+	 * @see   process_delete_notes
 	 *
 	 * @return void
 	 */
@@ -299,10 +301,10 @@ class GravityView_Field_Notes extends GravityView_Field {
 				$data = $post;
 			}
 
-			$required_args = array(
+			$required_args = [
 				'gv_delete_notes' => '',
 				'entry-slug'      => '',
-			);
+			];
 
 			$data = wp_parse_args( $data, $required_args );
 
@@ -313,15 +315,15 @@ class GravityView_Field_Notes extends GravityView_Field {
 	/**
 	 * Handle deleting notes
 	 *
-	 * @var array $data {
-	 *  @type string $action "gv_delete_notes"
-	 *  @type string $entry-slug Entry slug or ID to add note to
-	 *  @type string $gv_delete_notes Nonce with action "gv_delete_notes_{entry slug}" and name "gv_delete_notes"
-	 *  @type string $_wp_http_referer Relative URL to submitting page ('/view/example/entry/123/')
-	 *  @type int[]  $note  Array of Note IDs to be deleted
-	 * }
-	 *
 	 * @return void
+	 * @var array   $data             {
+	 * @type string $action           "gv_delete_notes"
+	 * @type string $entry            -slug Entry slug or ID to add note to
+	 * @type string $gv_delete_notes  Nonce with action "gv_delete_notes_{entry slug}" and name "gv_delete_notes"
+	 * @type string $_wp_http_referer Relative URL to submitting page ('/view/example/entry/123/')
+	 * @type int[]  $note             Array of Note IDs to be deleted
+	 *                                }
+	 *
 	 */
 	function process_delete_notes( $data ) {
 
@@ -345,7 +347,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 					$error_message = self::strings( 'error-permission-delete' );
 				}
 
-				wp_send_json_error( array( 'error' => $error_message ) );
+				wp_send_json_error( [ 'error' => $error_message ] );
 			}
 		}
 	}
@@ -371,37 +373,37 @@ class GravityView_Field_Notes extends GravityView_Field {
 
 		unset( $field_options['show_as_link'] );
 
-		$notes_options = array(
-			'notes' => array(
+		$notes_options = [
+			'notes' => [
 				'type'    => 'checkboxes',
 				'label'   => __( 'Note Settings', 'gk-gravityview' ),
 				'desc'    => sprintf( _x( 'Only users with specific capabilities will be able to view, add and delete notes. %1$sRead more%2$s.', '%s is opening and closing HTML link', 'gk-gravityview' ), '<a href="https://docs.gravitykit.com/article/311-gravityview-capabilities">', '</a>' ),
-				'options' => array(
-					'view'           => array(
+				'options' => [
+					'view'           => [
 						'label' => __( 'Display notes?', 'gk-gravityview' ),
-					),
-					'view_loggedout' => array(
+					],
+					'view_loggedout' => [
 						'label'    => __( 'Display notes to users who are not logged-in?', 'gk-gravityview' ),
 						'requires' => 'view',
-					),
-					'add'            => array(
+					],
+					'add'            => [
 						'label' => __( 'Enable adding notes?', 'gk-gravityview' ),
-					),
-					'email'          => array(
+					],
+					'email'          => [
 						'label'    => __( 'Allow emailing notes?', 'gk-gravityview' ),
 						'requires' => 'add',
-					),
-					'delete'         => array(
+					],
+					'delete'         => [
 						'label' => __( 'Allow deleting notes?', 'gk-gravityview' ),
-					),
-				),
-				'value'   => array(
+					],
+				],
+				'value'   => [
 					'view'  => 1,
 					'add'   => 1,
 					'email' => 1,
-				),
-			),
-		);
+				],
+			],
+		];
 
 		return $notes_options + $field_options;
 	}
@@ -419,7 +421,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 	 */
 	public static function strings( $key = '' ) {
 
-		$strings = array(
+		$strings = [
 			'add-note'              => __( 'Add Note', 'gk-gravityview' ),
 			'added-note'            => __( 'Note added.', 'gk-gravityview' ),
 			'content-label'         => __( 'Note Content', 'gk-gravityview' ),
@@ -435,19 +437,20 @@ class GravityView_Field_Notes extends GravityView_Field {
 			'subject-label'         => __( 'Subject', 'gk-gravityview' ),
 			'subject'               => __( 'Email subject', 'gk-gravityview' ),
 			'default-email-subject' => __( 'New entry note', 'gk-gravityview' ),
-            'email-footer'          => __( 'This note was sent from {url}', 'gk-gravityview' ),
+			'email-footer'          => __( 'This note was sent from {url}', 'gk-gravityview' ),
 			'also-email'            => __( 'Also email this note to', 'gk-gravityview' ),
 			'error-add-note'        => __( 'There was an error adding the note.', 'gk-gravityview' ),
 			'error-invalid'         => __( 'The request was invalid. Refresh the page and try again.', 'gk-gravityview' ),
 			'error-empty-note'      => _x( 'Note cannot be blank.', 'Message to display when submitting a note without content.', 'gk-gravityview' ),
 			'error-cap-delete'      => __( 'You don\'t have the ability to delete notes.', 'gk-gravityview' ),
 			'error-cap-add'         => __( 'You don\'t have the ability to add notes.', 'gk-gravityview' ),
-		);
+		];
 
 		/**
 		 * after return.
 		 *
 		 * @since 1.17
+		 *
 		 * @param array $strings Text in key => value pairs
 		 */
 		$strings = gv_map_deep( apply_filters( 'gravityview/field/notes/strings', $strings ), 'esc_html' );
@@ -464,11 +467,12 @@ class GravityView_Field_Notes extends GravityView_Field {
 	 *
 	 * @since 1.17
 	 *
-	 * @param object               $note Note object with id, user_id, date_created, value, note_type, user_name, user_email vars
+	 * @since 2.0
+	 *
 	 * @param bool                 $show_delete Whether to show the bulk delete inputs
 	 *
-	 * @since 2.0
-	 * @param \GV\Template_Context $context The context.
+	 * @param object               $note        Note object with id, user_id, date_created, value, note_type, user_name, user_email vars
+	 * @param \GV\Template_Context $context     The context.
 	 *
 	 * @return string HTML
 	 */
@@ -478,7 +482,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 			return '';
 		}
 
-		$note_content = array(
+		$note_content = [
 			'avatar'                 => get_avatar( $note->user_id, 48 ),
 			'user_name'              => $note->user_name,
 			'user_email'             => $note->user_email,
@@ -489,17 +493,18 @@ class GravityView_Field_Notes extends GravityView_Field {
 			'user_id'                => intval( $note->user_id ),
 			'note_type'              => $note->note_type,
 			'note_id'                => intval( $note->id ),
-		);
+		];
 
 		/**
 		 * Modify the note content before rendering in the template.
 		 *
 		 * @since 1.17
-		 * @param array $note_content Array of note content that will be replaced in template files
-		 * @param object $note Note object with id, user_id, date_created, value, note_type, user_name, user_email vars
-		 * @param boolean $show_delete True: Notes are editable. False: no editing notes.
 		 * @since 2.0
-		 * @param \GV\Template_Context $context The context.
+		 *
+		 * @param object               $note         Note object with id, user_id, date_created, value, note_type, user_name, user_email vars
+		 * @param boolean              $show_delete  True: Notes are editable. False: no editing notes.
+		 * @param array                $note_content Array of note content that will be replaced in template files
+		 * @param \GV\Template_Context $context      The context.
 		 */
 		$note_content = apply_filters( 'gravityview/field/notes/content', $note_content, $note, $show_delete, $context );
 
@@ -507,11 +512,11 @@ class GravityView_Field_Notes extends GravityView_Field {
 
 		if ( $context instanceof \GV\Template_Context ) {
 
-		    ob_start();
-		    $context->template->get_template_part( 'note', 'detail', true );
-            $note_detail_html = ob_get_clean();
+			ob_start();
+			$context->template->get_template_part( 'note', 'detail', true );
+			$note_detail_html = ob_get_clean();
 
-            ob_start();
+			ob_start();
 			$context->template->get_template_part( 'note', $note_row_template, true );
 			$note_row = ob_get_clean();
 
@@ -530,11 +535,11 @@ class GravityView_Field_Notes extends GravityView_Field {
 			$note_detail_html = str_replace( '{' . $tag . '}', $value ?? '', $note_detail_html );
 		}
 
-		$replacements = array(
+		$replacements = [
 			'{note_id}'     => $note_content['note_id'],
 			'{row_class}'   => 'gv-note',
 			'{note_detail}' => $note_detail_html,
-		);
+		];
 
 		// Strip extra whitespace in template
 		$output = gravityview_strip_whitespace( $note_row );
@@ -551,7 +556,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 	 *
 	 * @since 1.17
 	 *
-	 * @see GravityView_Entry_Notes::add_note This method is mostly a wrapper
+	 * @see   GravityView_Entry_Notes::add_note This method is mostly a wrapper
 	 *
 	 * @param array $entry
 	 * @param array $data Note details array
@@ -580,17 +585,19 @@ class GravityView_Field_Notes extends GravityView_Field {
 	 * @since 1.17
 	 *
 	 * @since 2.0
-	 * @param array                $atts Shortcode attributes for entry ID
+	 *
+	 * @param array                $atts    Shortcode attributes for entry ID
 	 * @param \GV\Template_Context $context The context, when called outside of a shortcode
 	 *
 	 * @return string HTML of the Add Note form, or empty string if the user doesn't have the `gravityview_add_entry_notes` cap
 	 */
 	public static function get_add_note_part( $atts, $context = null ) {
 
-		$atts = shortcode_atts( array( 'entry' => null ), $atts );
+		$atts = shortcode_atts( [ 'entry' => null ], $atts );
 
 		if ( ! GVCommon::has_cap( 'gravityview_add_entry_notes' ) ) {
 			gravityview()->log->error( 'User does not have permission to add entry notes ("gravityview_add_entry_notes").' );
+
 			return '';
 		}
 
@@ -637,7 +644,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 		$add_note_html = str_replace( '{nonce_field}', $nonce_field, $add_note_html );
 		$add_note_html = str_replace( '{show_delete}', (string) intval( empty( $visibility_settings['delete'] ) ? 0 : $visibility_settings['delete'] ), $add_note_html );
 		$add_note_html = str_replace( '{email_fields}', $email_fields, $add_note_html );
-		$add_note_html = str_replace( '{url}', esc_url_raw( add_query_arg( array() ) ), $add_note_html );
+		$add_note_html = str_replace( '{url}', esc_url_raw( add_query_arg( [] ) ), $add_note_html );
 
 		return $add_note_html;
 	}
@@ -658,11 +665,11 @@ class GravityView_Field_Notes extends GravityView_Field {
 
 		$entry = $gravityview_view->getCurrentEntry();
 
-		$note_emails = array();
+		$note_emails = [];
 
 		foreach ( $email_fields as $email_field ) {
-			if ( ! empty( $entry[ "{$email_field->id}" ] ) && is_email( $entry[ "{$email_field->id}" ] ) ) {
-				$note_emails[] = $entry[ "{$email_field->id}" ];
+			if ( ! empty( $entry["{$email_field->id}"] ) && is_email( $entry["{$email_field->id}"] ) ) {
+				$note_emails[] = $entry["{$email_field->id}"];
 			}
 		}
 
@@ -670,8 +677,9 @@ class GravityView_Field_Notes extends GravityView_Field {
 		 * Modify the dropdown values displayed in the "Also email note to" dropdown.
 		 *
 		 * @since 1.17
+		 *
 		 * @param array $note_emails Array of email addresses connected to the entry
-		 * @param array $entry Current entry
+		 * @param array $entry       Current entry
 		 */
 		$note_emails = apply_filters( 'gravityview/field/notes/emails', $note_emails, $entry );
 
@@ -681,9 +689,9 @@ class GravityView_Field_Notes extends GravityView_Field {
 	/**
 	 * Generate a HTML dropdown of email values based on email fields from the current form
 	 *
-	 * @uses get_note_emails_array
-	 *
 	 * @since 1.17
+	 *
+	 * @uses  get_note_emails_array
 	 *
 	 * @param int|string $entry_slug Current entry unique ID
 	 *
@@ -693,6 +701,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 
 		if ( ! GVCommon::has_cap( 'gravityview_email_entry_notes' ) ) {
 			gravityview()->log->error( 'User does not have permission to email entry notes ("gravityview_email_entry_notes").' );
+
 			return '';
 		}
 
@@ -706,6 +715,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 		 * Whether to include a Custom Email option for users to define a custom email to mail notes to.
 		 *
 		 * @since 1.17
+		 *
 		 * @param bool $include_custom Default: true
 		 */
 		$include_custom = apply_filters( 'gravityview/field/notes/custom-email', true );
@@ -718,31 +728,31 @@ class GravityView_Field_Notes extends GravityView_Field {
 				<select class="gv-note-email-to" name="gv-note-to" id="gv-note-email-to-<?php echo $entry_slug_esc; ?>">
 					<option value=""><?php echo $strings['also-email']; ?></option>
 					<?php
-                    foreach ( $note_emails as  $email ) {
+					foreach ( $note_emails as $email ) {
 						?>
 						<option value="<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></option>
 						<?php
-                    }
+					}
 					if ( $include_custom ) {
 						?>
-					<option value="custom"><?php echo self::strings( 'other-email' ); ?></option>
+						<option value="custom"><?php echo self::strings( 'other-email' ); ?></option>
 					<?php } ?>
 				</select>
 				<fieldset class="gv-note-to-container">
 					<?php if ( $include_custom ) { ?>
-					<div class='gv-note-to-custom-container'>
-						<label for="gv-note-email-to-custom-<?php echo $entry_slug_esc; ?>"><?php echo $strings['email-label']; ?></label>
-						<input type="text" name="gv-note-to-custom" placeholder="<?php echo $strings['email-placeholder']; ?>" id="gv-note-to-custom-<?php echo $entry_slug_esc; ?>" value="" />
-					</div>
+						<div class='gv-note-to-custom-container'>
+							<label for="gv-note-email-to-custom-<?php echo $entry_slug_esc; ?>"><?php echo $strings['email-label']; ?></label>
+							<input type="text" name="gv-note-to-custom" placeholder="<?php echo $strings['email-placeholder']; ?>" id="gv-note-to-custom-<?php echo $entry_slug_esc; ?>" value="" />
+						</div>
 					<?php } ?>
-		            <div class='gv-note-subject-container'>
-		                <label for="gv-note-subject-<?php echo $entry_slug_esc; ?>"><?php echo $strings['subject-label']; ?></label>
-		                <input type="text" name="gv-note-subject" placeholder="<?php echo $strings['subject']; ?>" id="gv-note-subject-<?php echo $entry_slug_esc; ?>" value="" />
-		            </div>
+					<div class='gv-note-subject-container'>
+						<label for="gv-note-subject-<?php echo $entry_slug_esc; ?>"><?php echo $strings['subject-label']; ?></label>
+						<input type="text" name="gv-note-subject" placeholder="<?php echo $strings['subject']; ?>" id="gv-note-subject-<?php echo $entry_slug_esc; ?>" value="" />
+					</div>
 				</fieldset>
 			</div>
 			<?php
-        }
+		}
 
 		// TODO: Add a filter
 		return ob_get_clean();
@@ -753,31 +763,32 @@ class GravityView_Field_Notes extends GravityView_Field {
 	 *
 	 * @since 1.17
 	 *
-	 * @param false|object $note If note was created, object. Otherwise, false.
+	 * @param false|object $note  If note was created, object. Otherwise, false.
 	 * @param array        $entry Entry data.
-	 * @param array        $data $_POST data.
+	 * @param array        $data  $_POST data.
 	 *
 	 * @return void Tap in to Gravity Forms' `gform_after_email` action if you want a return result from sending the email.
 	 */
-	private function maybe_send_entry_notes( $note = false, $entry = array(), $data = array() ) {
+	private function maybe_send_entry_notes( $note = false, $entry = [], $data = [] ) {
 
 		if ( ! $note || ! GVCommon::has_cap( 'gravityview_email_entry_notes' ) ) {
-			gravityview()->log->debug( 'User doesn\'t have "gravityview_email_entry_notes" cap, or $note is empty', array( 'data' => $note ) );
+			gravityview()->log->debug( 'User doesn\'t have "gravityview_email_entry_notes" cap, or $note is empty', [ 'data' => $note ] );
+
 			return;
 		}
 
-		gravityview()->log->debug( '$data', array( 'data' => $data ) );
+		gravityview()->log->debug( '$data', [ 'data' => $data ] );
 
 		// emailing notes if configured
 		if ( ! empty( $data['gv-note-to'] ) ) {
 
-			$default_data = array(
+			$default_data = [
 				'gv-note-to'        => '',
 				'gv-note-to-custom' => '',
 				'gv-note-subject'   => '',
 				'gv-note-content'   => '',
-                'current-url'       => '',
-			);
+				'current-url'       => '',
+			];
 
 			$current_user = wp_get_current_user();
 			$email_data   = wp_parse_args( $data, $default_data );
@@ -794,17 +805,18 @@ class GravityView_Field_Notes extends GravityView_Field {
 
 			if ( 'custom' === $to && $include_custom ) {
 				$to = $email_data['gv-note-to-custom'];
-				gravityview()->log->debug( 'Sending note to a custom email address: {to}', array( 'to' => $to ) );
+				gravityview()->log->debug( 'Sending note to a custom email address: {to}', [ 'to' => $to ] );
 			}
 
 			if ( ! GFCommon::is_valid_email_list( $to ) ) {
 				gravityview()->log->error(
-                    '$to not a valid email or email list (CSV of emails): {to}',
-                    array(
+					'$to not a valid email or email list (CSV of emails): {to}',
+					[
 						'to'   => print_r( $to, true ),
 						'data' => $email_data,
-                    )
-                );
+					]
+				);
+
 				return;
 			}
 
@@ -822,8 +834,9 @@ class GravityView_Field_Notes extends GravityView_Field {
 			/**
 			 * Modify the values passed when sending a note email.
 			 *
-			 * @see GVCommon::send_email
 			 * @since 1.17
+			 * @see   GVCommon::send_email
+			 *
 			 * @param array $email_settings Values being passed to the GVCommon::send_email() method: 'from', 'to', 'bcc', 'reply_to', 'subject', 'message', 'from_name', 'message_format', 'entry', 'email_footer'
 			 */
 			$email_content = apply_filters( 'gravityview/field/notes/email_content', compact( 'from', 'to', 'bcc', 'reply_to', 'subject', 'message', 'from_name', 'message_format', 'entry', 'email_footer' ) );
@@ -839,6 +852,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 			 * Should the message content have paragraphs added automatically, if using HTML message format.
 			 *
 			 * @since 1.18
+			 *
 			 * @param bool $wpautop_email True: Apply wpautop() to the email message if using; False: Leave as entered (Default: true)
 			 */
 			$wpautop_email = apply_filters( 'gravityview/field/notes/wpautop_email', true );
@@ -849,7 +863,7 @@ class GravityView_Field_Notes extends GravityView_Field {
 
 			GVCommon::send_email( $from, $to, $bcc, $reply_to, $subject, $message, $from_name, $message_format, '', $entry, false );
 
-			$form = isset( $entry['form_id'] ) ? GVCommon::get_form( $entry['form_id'] ) : array();
+			$form = isset( $entry['form_id'] ) ? GVCommon::get_form( $entry['form_id'] ) : [];
 
 			/**
 			 * @see https://www.gravityhelp.com/documentation/article/10146-2/ It's here for compatibility with Gravity Forms
@@ -859,24 +873,24 @@ class GravityView_Field_Notes extends GravityView_Field {
 	}
 
 	/**
-     * Get the footer for Entry Note emails
-     *
-     * `{url}` is replaced by the URL of the page where the note form was embedded
-     *
-     * @since 1.18
-     * @see GravityView_Field_Notes::strings The default value of $message_footer is set here, with the key 'email-footer'
+	 * Get the footer for Entry Note emails
+	 *
+	 * `{url}` is replaced by the URL of the page where the note form was embedded
+	 *
+	 * @since 1.18
+	 * @see   GravityView_Field_Notes::strings The default value of $message_footer is set here, with the key 'email-footer'
 	 *
 	 * @param string $email_footer The message footer value
-	 * @param bool   $is_html True: Email is being sent as HTML; False: sent as text
+	 * @param bool   $is_html      True: Email is being sent as HTML; False: sent as text
 	 *
 	 * @return string If email footer is not empty, return the message with placeholders replaced with dynamic values
 	 */
-	private function get_email_footer( $email_footer = '', $is_html = true, $email_data = array() ) {
+	private function get_email_footer( $email_footer = '', $is_html = true, $email_data = [] ) {
 
-	    $output = '';
+		$output = '';
 
 		if ( ! empty( $email_footer ) ) {
-		    $url = \GV\Utils::get( $email_data, 'current-url' );
+			$url = \GV\Utils::get( $email_data, 'current-url' );
 			$url = html_entity_decode( $url );
 			$url = site_url( $url );
 

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -51,7 +51,7 @@ class GravityView_Lightbox_Entry {
 	 *
 	 * @used-by `gravityview/template/before` filter.
 	 *
-	 * @since 2.29.0
+	 * @since   2.29.0
 	 *
 	 * @param Template_Context $context
 	 *
@@ -151,7 +151,7 @@ class GravityView_Lightbox_Entry {
 	 *
 	 * @used-by `gravityview/view/links/directory` filter.
 	 *
-	 * @since 2.29.0
+	 * @since   2.29.0
 	 *
 	 * @param string $link The directory link.
 	 *
@@ -323,6 +323,8 @@ class GravityView_Lightbox_Entry {
 			return;
 		}
 
+		add_filter( 'gk/gravityview/edit-entry/renderer/enqueue-entry-lock-assets', '__return_true' );
+
 		add_filter( 'gravityview/edit_entry/verify_nonce', '__return_true' );
 
 		add_filter( 'gravityview/edit_entry/cancel_onclick', function () use ( $view ) {
@@ -331,6 +333,25 @@ class GravityView_Lightbox_Entry {
 			} else {
 				return '';
 			}
+		} );
+
+		// Updates the GF entry lock UI markup to properly handle requests for accepting the release or taking over the edit lock.
+		add_filter( 'gk/gravityview/edit-entry/renderer/entry-lock-dialog-markup', function ( $markup ) {
+			// To accept the release, we do an Ajax GET request by passing "release-edit-lock=1" and then close the lightbox.
+			$markup = str_replace(
+				'id="gform-release-lock-button"',
+				'id="gform-release-lock-button" onclick="event.preventDefault(); jQuery.ajax({ url: window.location.href, data: { \'release-edit-lock\': 1 }, method: \'GET\', dataType: \'html\' }).done(function() { window.parent.postMessage({ closeFancybox: true }); });"',
+				$markup
+			);
+
+			// To take over once the release has been accepted, we do an Ajax GET request by passing "get-edit-lock=1" and then close the GF lock dialog window.
+			$markup = str_replace(
+				'id="gform-take-over-button"',
+				'id="gform-take-over-button" onclick="event.preventDefault(); jQuery.ajax({ url: window.location.href, data: { \'get-edit-lock\': 1 }, method: \'GET\', dataType: \'html\' }).done(function() { jQuery( \'#gform-lock-dialog\' ).hide(); });"',
+				$markup
+			);
+
+			return $markup;
 		} );
 
 		// Prevent redirection inside the lightbox by sending event to the parent window and hiding the success message.
@@ -488,14 +509,15 @@ class GravityView_Lightbox_Entry {
 		 *
 		 * @action `gk/gravityview/lightbox/entry/before-output`
 		 *
-		 * @since 2.31.0
+		 * @since  2.31.0
 		 *
-		 * @param array $args {
-		 *     @type View         $view            The View object being rendered.
-		 *     @type GF_Entry     $entry           The Gravity Forms entry data.
-		 *     @type array        $form            The Gravity Forms form array.
-		 *     @type Entry_Render $entry_renderer  The renderer object responsible for rendering the entry.
-		 * }
+		 * @param array       $args           {
+		 *
+		 * @type View         $view           The View object being rendered.
+		 * @type GF_Entry     $entry          The Gravity Forms entry data.
+		 * @type array        $form           The Gravity Forms form array.
+		 * @type Entry_Render $entry_renderer The renderer object responsible for rendering the entry.
+		 *                                    }
 		 */
 		do_action_ref_array( 'gk/gravityview/lightbox/entry/before-output', [ &$view, &$entry, &$form, &$entry_renderer ] );
 
@@ -519,19 +541,19 @@ class GravityView_Lightbox_Entry {
 		<html lang="<?php echo get_bloginfo( 'language' ); ?>">
 			<head>
 				<?php
-					/**
-					 * Fires after <head> tag.
-					 *
-					 * @action `gk/gravityview/lightbox/entry/output/head-before`
-					 *
-					 * @since 2.31.0
-					 *
-					 * @param string   $type  The type of the entry view (single or edit).
-					 * @param View     $view  The View object being rendered.
-					 * @param GF_Entry $entry The Gravity Forms entry data.
-					 * @param array    $form  The Gravity Forms form array.
-					 */
-					do_action( 'gk/gravityview/lightbox/entry/output/head-before', $type, $view, $entry, $form );
+				/**
+				 * Fires after <head> tag.
+				 *
+				 * @action `gk/gravityview/lightbox/entry/output/head-before`
+				 *
+				 * @since  2.31.0
+				 *
+				 * @param string   $type  The type of the entry view (single or edit).
+				 * @param View     $view  The View object being rendered.
+				 * @param GF_Entry $entry The Gravity Forms entry data.
+				 * @param array    $form  The Gravity Forms form array.
+				 */
+				do_action( 'gk/gravityview/lightbox/entry/output/head-before', $type, $view, $entry, $form );
 				?>
 
 				<title><?php echo $title; ?></title>
@@ -547,73 +569,73 @@ class GravityView_Lightbox_Entry {
 				</script>
 
 				<?php
-					/**
-					 * Fires before </head> tag.
-					 *
-					 * @action `gk/gravityview/lightbox/entry/output/head-after`
-					 *
-					 * @since 2.31.0
-					 *
-					 * @param string   $type  The type of the entry view (single or edit).
-					 * @param View     $view  The View object being rendered.
-					 * @param GF_Entry $entry The Gravity Forms entry data.
-					 * @param array    $form  The Gravity Forms form array.
-					 */
-					do_action( 'gk/gravityview/lightbox/entry/output/head-after', $type, $view, $entry, $form );
+				/**
+				 * Fires before </head> tag.
+				 *
+				 * @action `gk/gravityview/lightbox/entry/output/head-after`
+				 *
+				 * @since  2.31.0
+				 *
+				 * @param string   $type  The type of the entry view (single or edit).
+				 * @param View     $view  The View object being rendered.
+				 * @param GF_Entry $entry The Gravity Forms entry data.
+				 * @param array    $form  The Gravity Forms form array.
+				 */
+				do_action( 'gk/gravityview/lightbox/entry/output/head-after', $type, $view, $entry, $form );
 				?>
 			</head>
 
 			<body>
 				<?php
-					/**
-					 * Fires after <body> tag before the content is rendered.
-					 *
-					 * @action `gk/gravityview/lightbox/entry/output/content-before`
-					 *
-					 * @since 2.31.0
-					 *
-					 * @param string   $type  The type of the entry view (single or edit).
-					 * @param View     $view  The View object being rendered.
-					 * @param GF_Entry $entry The Gravity Forms entry data.
-					 * @param array    $form  The Gravity Forms form array.
-					 */
-					do_action( 'gk/gravityview/lightbox/entry/output/content-before', $type, $view, $entry, $form );
+				/**
+				 * Fires after <body> tag before the content is rendered.
+				 *
+				 * @action `gk/gravityview/lightbox/entry/output/content-before`
+				 *
+				 * @since  2.31.0
+				 *
+				 * @param string   $type  The type of the entry view (single or edit).
+				 * @param View     $view  The View object being rendered.
+				 * @param GF_Entry $entry The Gravity Forms entry data.
+				 * @param array    $form  The Gravity Forms form array.
+				 */
+				do_action( 'gk/gravityview/lightbox/entry/output/content-before', $type, $view, $entry, $form );
 				?>
 
 				<?php echo $content; ?>
 
 				<?php
-					/**
-					 * Fires inside the <body> tag after the content is rendered and before the footer.
-					 *
-					 * @action `gk/gravityview/lightbox/entry/output/content-after`
-					 *
-					 * @since 2.31.0
-					 *
-					 * @param string   $type  The type of the entry view (single or edit).
-					 * @param View     $view  The View object being rendered.
-					 * @param GF_Entry $entry The Gravity Forms entry data.
-					 * @param array    $form  The Gravity Forms form array.
-					 */
-					do_action( 'gk/gravityview/lightbox/entry/output/content-after', $type, $view, $entry, $form );
+				/**
+				 * Fires inside the <body> tag after the content is rendered and before the footer.
+				 *
+				 * @action `gk/gravityview/lightbox/entry/output/content-after`
+				 *
+				 * @since  2.31.0
+				 *
+				 * @param string   $type  The type of the entry view (single or edit).
+				 * @param View     $view  The View object being rendered.
+				 * @param GF_Entry $entry The Gravity Forms entry data.
+				 * @param array    $form  The Gravity Forms form array.
+				 */
+				do_action( 'gk/gravityview/lightbox/entry/output/content-after', $type, $view, $entry, $form );
 				?>
 
 				<?php wp_footer(); ?>
 
 				<?php
-					/**
-					 * Fires after the footer and before the closing </body> tag.
-					 *
-					 * @action `gk/gravityview/lightbox/entry/output/footer-after`
-					 *
-					 * @since 2.31.0
-					 *
-					 * @param string   $type  The type of the entry view (single or edit).
-					 * @param View     $view  The View object being rendered.
-					 * @param GF_Entry $entry The Gravity Forms entry data.
-					 * @param array    $form  The Gravity Forms form array.
-					 */
-					do_action( 'gk/gravityview/lightbox/entry/output/footer-after', $type, $view, $entry, $form );
+				/**
+				 * Fires after the footer and before the closing </body> tag.
+				 *
+				 * @action `gk/gravityview/lightbox/entry/output/footer-after`
+				 *
+				 * @since  2.31.0
+				 *
+				 * @param string   $type  The type of the entry view (single or edit).
+				 * @param View     $view  The View object being rendered.
+				 * @param GF_Entry $entry The Gravity Forms entry data.
+				 * @param array    $form  The Gravity Forms form array.
+				 */
+				do_action( 'gk/gravityview/lightbox/entry/output/footer-after', $type, $view, $entry, $form );
 				?>
 			</body>
 		</html>
@@ -631,7 +653,7 @@ class GravityView_Lightbox_Entry {
 	 *
 	 * @used-by `gk/foundation/inline-scripts` filter.
 	 *
-	 * @since 2.29.0
+	 * @since   2.29.0
 	 *
 	 * @param array $scripts The registered scripts.
 	 *
@@ -725,7 +747,7 @@ class GravityView_Lightbox_Entry {
 	 * @since 2.31.0
 	 *
 	 * @param string $type The type of the entry view (single or edit).
-	 * @param View $view The View object being rendered.
+	 * @param View   $view The View object being rendered.
 	 *
 	 * @return void
 	 */

--- a/includes/fields/class-gravityview-field-date.php
+++ b/includes/fields/class-gravityview-field-date.php
@@ -23,10 +23,7 @@ class GravityView_Field_Date extends GravityView_Field {
 	var $icon = 'dashicons-calendar-alt';
 
 	public function __construct() {
-
 		$this->label = esc_html__( 'Date', 'gk-gravityview' );
-
-		add_filter( 'gravityview/merge_tags/modifiers/value', array( $this, 'apply_format_date_modifiers' ), 10, 6 );
 
 		parent::__construct();
 	}
@@ -40,39 +37,6 @@ class GravityView_Field_Date extends GravityView_Field {
 		$this->add_field_support( 'date_display', $field_options );
 
 		return $field_options;
-	}
-
-	/**
-	 * Allow Date fields to take advantage of the GV date modifiers
-	 *
-	 * @since 2.0
-	 * @uses  GravityView_Merge_Tags::format_date
-	 *
-	 * @param string   $return The current merge tag value to be filtered.
-	 * @param string   $raw_value The raw value submitted for this field. May be CSV or JSON-encoded.
-	 * @param string   $value The original merge tag value, passed from Gravity Forms
-	 * @param string   $merge_tag If the merge tag being executed is an individual field merge tag (i.e. {Name:3}), this variable will contain the field's ID. If not, this variable will contain the name of the merge tag (i.e. all_fields).
-	 * @param string   $modifier The string containing any modifiers for this merge tag. For example, "maxwords:10" would be the modifiers for the following merge tag: `{Text:2:maxwords:10}`.
-	 * @param GF_Field $field The current field.
-	 *
-	 * @return string If Date field, run it through GravityView_Merge_Tags::format_date; otherwise, return the original value
-	 */
-	public function apply_format_date_modifiers( $return, $raw_value = '', $value = '', $merge_tag = '', $modifier = '', $field = null ) {
-		if ( 'date' === $field->type ) {
-			// If human modifier is used, don't change anything as it's already been formatted.
-			if ( strpos( $modifier, 'human' ) !== false ) {
-				return $return;
-			}
-
-			// Skip the timezone offset.
-			if ( false === strpos( $modifier, 'no_tz_offset' ) ) {
-				$modifier = 'no_tz_offset:' . $modifier;
-			}
-
-			$return = GravityView_Merge_Tags::format_date( $raw_value, $modifier );
-		}
-
-		return $return;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * Users belonging to the main network site in a multisite environment couldn’t delete their own entries on subsites.
 * Entry locking not working.
 * JavaScript error preventing entry notes from being added when using the Twenty Twenty-Two theme or newer.
+* Using a comma in the `:format` merge tag modifier with Date fields caused partial results to be returned.
 
 #### 💻 Developer Updates
 * Added `gk/gravityview/edit-entry/renderer/enqueue-entry-lock-assets` filter to override whether to load the entry lock UI assets.

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 #### 🐛 Fixed
 * The Search Bar would not always be visible in Views using the Layout Builder.
 * Users belonging to the main network site in a multisite environment couldn’t delete their own entries on subsites.
+* Entry locking not working.
+
+#### 💻 Developer Updates
+* Added `gk/gravityview/edit-entry/renderer/enqueue-entry-lock-assets` filter to override whether to load the entry lock UI assets.
+* Added `gk/gravityview/edit-entry/renderer/entry-lock-dialog-markup` filter to modify the entry locking UI dialog window markup.
 
 = 2.34 on January 9, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
-= develop =
+= 2.34.1 on January 30, 2025 =
+
+This update resolves multiple issues, including problems with search bar visibility in Layout Builder, entry management in multisite environments, and non-functional entry locking and notes, among others.
 
 #### 🐛 Fixed
 * The Search Bar would not always be visible in Views using the Layout Builder.

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+* Fixed: The Search Bar would not always be visible on Views with the Layout Builder.
+
 = 2.34 on January 9, 2025 =
 
 This release introduces the [Layout Builder](https://www.gravitykit.com/announcing-gravityview-2-34-all-new-layout-builder) that allows creating custom layouts with rows and columns directly in the View editor, adds support for exporting entries by Approval Status, and includes various fixes and improvements.

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
-* Fixed: The Search Bar would not always be visible on Views with the Layout Builder.
+#### 🐛 Fixed
+* The Search Bar would not always be visible in Views using the Layout Builder.
+* Users belonging to the main network site in a multisite environment couldn’t delete their own entries on subsites.
 
 = 2.34 on January 9, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * The Search Bar would not always be visible in Views using the Layout Builder.
 * Users belonging to the main network site in a multisite environment couldn’t delete their own entries on subsites.
 * Entry locking not working.
+* JavaScript error preventing entry notes from being added when using the Twenty Twenty-Two theme or newer.
 
 #### 💻 Developer Updates
 * Added `gk/gravityview/edit-entry/renderer/enqueue-entry-lock-assets` filter to override whether to load the entry lock UI assets.

--- a/templates/views/gravityview-layout-builder.php
+++ b/templates/views/gravityview-layout-builder.php
@@ -16,15 +16,17 @@ ob_start();
 gravityview_before( $gravityview );
 
 gravityview_header( $gravityview );
-
+?>
+<div class="<?php echo esc_attr( gv_container_class( 'gv-layout-builder-container', false, $gravityview ) ); ?>"
+<?php
 // There are no entries.
 if ( ! $gravityview->entries->count() ) {
 	?>
-	<div class="gv-layout-builder-view gv-no-results">
-		<div class="gv-layout-builder-view-title">
-			<h3><?php echo gv_no_results( true, $gravityview ); ?></h3>
-		</div>
-	</div>
+    <div class="gv-layout-builder-view gv-no-results">
+        <div class="gv-layout-builder-view-title">
+            <h3><?php echo gv_no_results( true, $gravityview ); ?></h3>
+        </div>
+    </div>
 	<?php
 } else {
 	$zone = 'directory';
@@ -35,14 +37,14 @@ if ( ! $gravityview->entries->count() ) {
 	// There are entries. Loop through them.
 	foreach ( $gravityview->entries->all() as $entry ) {
 		?>
-		<div class="gv-layout-builder-view gv-layout-builder-view--entry gv-grid">
+        <div class="gv-layout-builder-view gv-layout-builder-view--entry gv-grid">
 			<?php foreach ( $rows as $row ) { ?>
-				<div class="gv-grid-row">
+                <div class="gv-grid-row">
 					<?php
 					foreach ( $row as $col => $areas ) {
 						$column = $col;
 						?>
-						<div class="gv-grid-col-<?php echo esc_attr( $column ); ?>">
+                        <div class="gv-grid-col-<?php echo esc_attr( $column ); ?>">
 							<?php
 							if ( ! empty( $areas ) ) {
 								foreach ( $areas as $area ) {
@@ -52,15 +54,17 @@ if ( ! $gravityview->entries->count() ) {
 								}
 							}
 							?>
-						</div>
+                        </div>
 					<?php } // $row ?>
-				</div>
+                </div>
 			<?php } // $rows ?>
-		</div>
+        </div>
 		<?php
 	}
 }
-
+?>
+</div>
+<?php
 gravityview_footer( $gravityview );
 
 gravityview_after( $gravityview );
@@ -71,14 +75,13 @@ $content = ob_get_clean();
  *
  * @since  2.15
  *
- * @param string   $wrapper_container Wrapper container HTML markup
- * @param string   $anchor_id         (optional) Unique anchor ID to identify the view.
- * @param \GV\View $view              The View.
+ * @param string $wrapper_container Wrapper container HTML markup
+ * @param string $anchor_id         (optional) Unique anchor ID to identify the view.
+ * @param \GV\View $view            The View.
  */
-$class             = gv_container_class( 'gv-layout-builder-container', false, $gravityview );
 $wrapper_container = apply_filters(
 	'gravityview/view/wrapper_container',
-	'<div id="' . esc_attr( $gravityview->view->get_anchor_id() ) . '" class="' . esc_attr( $class ) . '">{content}</div>',
+	'<div id="' . esc_attr( $gravityview->view->get_anchor_id() ) . '">{content}</div>',
 	$gravityview->view->get_anchor_id(),
 	$gravityview->view
 );

--- a/tests/unit-tests/GravityView_Merge_Tags_Test.php
+++ b/tests/unit-tests/GravityView_Merge_Tags_Test.php
@@ -483,6 +483,7 @@ class GravityView_Merge_Tags_Test extends GV_UnitTestCase {
 		$form['fields'][] = new GF_Field_Text( array( 'id' => 101, 'form_id' => $form['id'] ) );
 		$form['fields'][] = new GF_Field_Text( array( 'id' => 201, 'form_id' => $form['id'] ) );
 		$form['fields'][] = new GF_Field_Text( array( 'id' => 301, 'form_id' => $form['id'] ) );
+		$form['fields'][] = new GF_Field_Date( array( 'id' => 501, 'form_id' => $form['id'] ) );
 
 		$list_field = new GF_Field_List( array( 'id' => 401, 'form_id' => $form['id'] ) );
 
@@ -493,6 +494,7 @@ class GravityView_Merge_Tags_Test extends GV_UnitTestCase {
 		$entry['201'] = '<tag>';
 		$entry['301'] = '["This","is","JSON"]';
 		$entry['401'] = 'a:2:{i:0;s:8:"One List";i:1;s:8:"Two List";}';
+		$entry['501'] = '2025-01-31';
 
 		$tests = array(
 			'{Field:100:sanitize_html_class}' => 'This is spaces',
@@ -529,6 +531,10 @@ class GravityView_Merge_Tags_Test extends GV_UnitTestCase {
 			'{List Field:401:text,urlencode}' => 'One+List%2C+Two+List',
 			'{List Field:401:html,esc_html}' => "&lt;ul class=&#039;bulleted&#039;&gt;&lt;li&gt;One List&lt;/li&gt;&lt;li&gt;Two List&lt;/li&gt;&lt;/ul&gt;",
 			'{List Field:401:non_gf_non_gv}' => 'One List, Two List',
+			'{Field:501:format:F j, Y}' => 'January 31', // Comma is not escaped
+			'{Field:501:format:F j\, Y}' => 'January 31, 2025',
+			'{Field:501:format:\j\a\n\u\a\r\y j\, Y,ucwords }' => 'January 31, 2025',
+			'{Field:501:format:\j\a\n\u\a\r\y j\, Y,ucwords,maxwords:2}' => 'January 31,&hellip;',
 		);
 
 		$filter_tags = function( $tags ) {


### PR DESCRIPTION
This update resolves multiple issues, including problems with search bar visibility in Layout Builder, entry management in multisite environments, and non-functional entry locking and notes, among others.

#### 🐛 Fixed
* The Search Bar would not always be visible in Views using the Layout Builder.
* Users belonging to the main network site in a multisite environment couldn’t delete their own entries on subsites.
* Entry locking not working.
* JavaScript error preventing entry notes from being added when using the Twenty Twenty-Two theme or newer.
* Using a comma in the `:format` merge tag modifier with Date fields caused partial results to be returned.

#### 💻 Developer Updates
* Added `gk/gravityview/edit-entry/renderer/enqueue-entry-lock-assets` filter to override whether to load the entry lock UI assets.
* Added `gk/gravityview/edit-entry/renderer/entry-lock-dialog-markup` filter to modify the entry locking UI dialog window markup.


💾 [Build file](https://www.dropbox.com/scl/fi/pe6nohvda0mhtf4szzt77/gravityview-2.34.1-4f94cf006.zip?rlkey=r5irn4uz1vux0peq4jn78mp60&dl=1) (4f94cf006).