### PR TITLE
Fix "function _load_textdomain_just_in_time was called incorrectly" notice

### DIFF
--- a/future/includes/class-gv-plugin.php
+++ b/future/includes/class-gv-plugin.php
@@ -210,10 +210,12 @@ final class Plugin {
 		include_once $this->dir( 'includes/fields/class-gravityview-fields.php' );
 		include_once $this->dir( 'includes/fields/class-gravityview-field.php' );
 
-		// Load all field files automatically
-		foreach ( glob( $this->dir( 'includes/fields/class-gravityview-field*.php' ) ) as $gv_field_filename ) {
-			include_once $gv_field_filename;
-		}
+		add_action( 'after_setup_theme', function () {
+			// Load all field files automatically
+			foreach ( glob( $this->dir( 'includes/fields/class-gravityview-field*.php' ) ) as $gv_field_filename ) {
+				include_once $gv_field_filename;
+			}
+		} );
 
 		include_once $this->dir( 'includes/class-gravityview-entry-approval-status.php' );
 		include_once $this->dir( 'includes/class-gravityview-entry-approval-merge-tags.php' );

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+#### 🐛 Fixed
+* PHP notice when translation loading was triggered too early, affecting non-`en_US` locale sites.
+
 = 2.34.1 on January 30, 2025 =
 
 This update resolves multiple issues, including problems with search bar visibility in Layout Builder, entry management in multisite environments, and non-functional entry locking and notes, among others.


### PR DESCRIPTION
This addresses #2268.

💾 [Build file](https://www.dropbox.com/scl/fi/5y76e4wyxev43i0wttzv0/gravityview-2.34.1-f1187ffdd.zip?rlkey=8qre5u1hkrsb87v8tyew1ppkf&dl=1) (f1187ffdd).