### PR TITLE
Release 2.34.2

### DIFF
--- a/future/includes/class-gv-plugin.php
+++ b/future/includes/class-gv-plugin.php
@@ -210,10 +210,12 @@ final class Plugin {
 		include_once $this->dir( 'includes/fields/class-gravityview-fields.php' );
 		include_once $this->dir( 'includes/fields/class-gravityview-field.php' );
 
-		// Load all field files automatically
-		foreach ( glob( $this->dir( 'includes/fields/class-gravityview-field*.php' ) ) as $gv_field_filename ) {
-			include_once $gv_field_filename;
-		}
+		add_action( 'after_setup_theme', function () {
+			// Load all field files automatically
+			foreach ( glob( $this->dir( 'includes/fields/class-gravityview-field*.php' ) ) as $gv_field_filename ) {
+				include_once $gv_field_filename;
+			}
+		} );
 
 		include_once $this->dir( 'includes/class-gravityview-entry-approval-status.php' );
 		include_once $this->dir( 'includes/class-gravityview-entry-approval-merge-tags.php' );

--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.34.1
+ * Version:             2.34.2
  * Requires PHP:        7.4.0
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
@@ -32,7 +32,7 @@ if ( ! GravityKit\GravityView\Foundation\meets_min_php_version_requirement( __FI
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.34.1' );
+define( 'GV_PLUGIN_VERSION', '2.34.2' );
 
 /**
  * Full path to the GravityView file

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -304,7 +304,7 @@ class GravityView_Welcome {
 
 				<ul>
 					<li><code>function _load_textdomain_just_in_time was called incorrectly</code> PHP notice in WordPress 6.7 or newer.</li>
-					<li>Display issue caused by a missing closing <code>div</code> tag in the Layout Builder View template.</li>
+					<li>Display issue caused by a malformed <code>div</code> tag in the Layout Builder View template.</li>
 				</ul>
 
 				<h3>2.34.1 on January 30, 2025</h3>

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -296,11 +296,22 @@ class GravityView_Welcome {
 				 *  - If 4.28, include to 4.26.
 				 */
 				?>
+				<h3>2.34.2 on February 4, 2025</h3>
+
+				<p>This release fixes a PHP notice in WordPress 6.7+ and a display issue in Views using the Layout Builder template.</p>
+
+				<h4>🐛 Fixed</h4>
+
+				<ul>
+					<li><code>function _load_textdomain_just_in_time was called incorrectly</code> PHP notice in WordPress 6.7 or newer.</li>
+					<li>Display issue caused by a missing closing <code>div</code> tag in the Layout Builder View template.</li>
+				</ul>
+
 				<h3>2.34.1 on January 30, 2025</h3>
 
 				<p>This update resolves multiple issues, including problems with search bar visibility in Layout Builder, entry management in multisite environments, and non-functional entry locking and notes, among others.</p>
 
-				<h4>🦛 Fixed</h4>
+				<h4>🐛 Fixed</h4>
 
 				<ul>
 					<li>The Search Bar would not always be visible in Views using the Layout Builder.</li>

--- a/readme.txt
+++ b/readme.txt
@@ -27,7 +27,7 @@ This release fixes a PHP notice in WordPress 6.7+ and a display issue in Views u
 
 #### 🐛 Fixed
 * `function _load_textdomain_just_in_time was called incorrectly` PHP notice in WordPress 6.7 or newer.
-* Display issue caused by a missing closing `div` tag in the Layout Builder View template.
+* Display issue caused by a malformed `div` tag in the Layout Builder View template.
 
 = 2.34.1 on January 30, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,11 +21,13 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
-= develop =
+= 2.34.2 on February 4, 2025 =
+
+This release fixes a PHP notice in WordPress 6.7+ and a display issue in Views using the Layout Builder template.
 
 #### 🐛 Fixed
-* PHP notice when translation loading was triggered too early, affecting non-`en_US` locale sites.
-* The Layout Builder View template was missing a closing tag, which could break the styling.
+* `function _load_textdomain_just_in_time was called incorrectly` PHP notice in WordPress 6.7 or newer.
+* Display issue caused by a missing closing `div` tag in the Layout Builder View template.
 
 = 2.34.1 on January 30, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+### Fixed
+* The Layout Builder View template was missing a closing tag, which could break the styling.
+
 = 2.34.1 on January 30, 2025 =
 
 This update resolves multiple issues, including problems with search bar visibility in Layout Builder, entry management in multisite environments, and non-functional entry locking and notes, among others.

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,8 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
-### Fixed
+#### 🐛 Fixed
+* PHP notice when translation loading was triggered too early, affecting non-`en_US` locale sites.
 * The Layout Builder View template was missing a closing tag, which could break the styling.
 
 = 2.34.1 on January 30, 2025 =

--- a/templates/views/gravityview-layout-builder.php
+++ b/templates/views/gravityview-layout-builder.php
@@ -17,7 +17,7 @@ gravityview_before( $gravityview );
 
 gravityview_header( $gravityview );
 ?>
-<div class="<?php echo esc_attr( gv_container_class( 'gv-layout-builder-container', false, $gravityview ) ); ?>"
+<div class="<?php echo esc_attr( gv_container_class( 'gv-layout-builder-container', false, $gravityview ) ); ?>">
 <?php
 // There are no entries.
 if ( ! $gravityview->entries->count() ) {


### PR DESCRIPTION
This release fixes a PHP notice in WordPress 6.7+ and a display issue in Views using the Layout Builder template.

#### 🐛 Fixed
* `function _load_textdomain_just_in_time was called incorrectly` PHP notice in WordPress 6.7 or newer.
* Display issue caused by a malformed `div` tag in the Layout Builder View template.
