### PR TITLE
Exclude partial entries from the Unapproved filter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -24,8 +24,10 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 = develop =
 
 #### 🚀 Added
-
 * Random sorting option in the GravityView block.
+
+#### ✨ Improved
+* Partial entries no longer appear as "Unapproved" on the Entries page.
 
 #### 🐛 Fixed
 


### PR DESCRIPTION
This implements #2273.

[Test site](https://gv-pr-2281.try.gravitykit.com/wp-admin/admin.php?page=gf_entries&id=2) (see InstaWP for credentials).

💾 [Build file](https://www.dropbox.com/scl/fi/rt1tgjcfrsucn7q5nzhob/gravityview-2.34.2-cc95f7f9b.zip?rlkey=vr3buygjrmmqv897ilxx2qdmr&dl=1) (cc95f7f9b).