### PR TITLE
Order forms alphabetically in the dropdown on the All Views page

### DIFF
--- a/includes/class-admin-views.php
+++ b/includes/class-admin-views.php
@@ -235,7 +235,7 @@ class GravityView_Admin_Views {
 			return;
 		}
 
-		$forms        = gravityview_get_forms(true, false, 'title', 'ASC');
+		$forms        = gravityview_get_forms( true, false, 'title' );
 		$current_form = \GV\Utils::_GET( 'gravityview_form_id' );
 
 		// If there are no forms to select, show no forms.

--- a/includes/class-admin-views.php
+++ b/includes/class-admin-views.php
@@ -235,7 +235,7 @@ class GravityView_Admin_Views {
 			return;
 		}
 
-		$forms        = gravityview_get_forms();
+		$forms        = gravityview_get_forms(true, false, 'title', 'ASC');
 		$current_form = \GV\Utils::_GET( 'gravityview_form_id' );
 
 		// If there are no forms to select, show no forms.

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -406,12 +406,12 @@ class GVCommon {
 
 
 		// Handle case-insensitive title sorting with uppercase/lowercase letters
-		if ( 'title' === $order_by ) {
-			usort( $forms, function( $a, $b ) use ( $order ) {
+		if ( ! empty( $forms ) && 'title' === $order_by ) {
+			uasort( $forms, function( $a, $b ) use ( $order ) {
 				$result = strcasecmp( $a['title'], $b['title'] );
 				return ( 'DESC' === $order ) ? -$result : $result;
 			});
-		} else {
+		} elseif ( ! empty( $forms ) ) {
 			$forms = wp_list_sort( $forms, $order_by, $order, true );
 		}
 

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -408,7 +408,7 @@ class GVCommon {
 		// Handle case-insensitive title sorting with uppercase/lowercase letters
 		if ( ! empty( $forms ) && 'title' === $order_by ) {
 			uasort( $forms, function( $a, $b ) use ( $order ) {
-				$result = strcasecmp( $a['title'], $b['title'] );
+				$result = strnatcasecmp( $a['title'], $b['title'] );
 				return ( 'DESC' === $order ) ? -$result : $result;
 			});
 		} elseif ( ! empty( $forms ) ) {

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -404,7 +404,16 @@ class GVCommon {
 			$forms = GFAPI::get_forms( $active, $trash );
 		}
 
-		$forms = wp_list_sort( $forms, $order_by, $order, true );
+
+		// Handle case-insensitive title sorting with uppercase/lowercase letters
+		if ( 'title' === $order_by ) {
+			usort( $forms, function( $a, $b ) use ( $order ) {
+				$result = strcasecmp( $a['title'], $b['title'] );
+				return ( 'DESC' === $order ) ? -$result : $result;
+			});
+		} else {
+			$forms = wp_list_sort( $forms, $order_by, $order, true );
+		}
 
 		/**
 		 * Modify the forms returned by GFAPI::get_forms().

--- a/readme.txt
+++ b/readme.txt
@@ -21,10 +21,13 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
-= develop = 
+= develop =
 
 #### 🚀 Added
 * New notification event "GravityView - Entry is duplicated" that runs when entries are duplicated using GravityView.
+
+#### ✨ Improved
+* Forms in the form selection filter on the Views page are now sorted alphabetically.
 
 = 2.35 on February 12, 2025 =
 


### PR DESCRIPTION
- Implements https://github.com/GravityKit/GravityView/issues/2262
- Orders the forms alphabetically
- Fixed `get_forms` as there was an issue with using wp_list_sort when it came to strings as it was ordering them wrong

💾 [Build file](https://www.dropbox.com/scl/fi/xwxri01502ee03636vi1w/gravityview-2.35-80df57f24.zip?rlkey=pwe8hzsotfvcaoq0uqnpbrloh&dl=1) (80df57f24).