### PR TITLE
Fix Edit Entry link in admin bar for multi entries

### DIFF
--- a/future/includes/class-gv-entry-multi.php
+++ b/future/includes/class-gv-entry-multi.php
@@ -46,6 +46,9 @@ class Multi_Entry extends Entry implements \ArrayAccess {
 			}
 			$_entry->entries[ $entry['form_id'] ] = &$entry;
 		}
+
+		$_entry->ID = reset( $_entry->entries )['id'] ?? null;
+
 		return $_entry;
 	}
 

--- a/includes/class-gravityview-admin-bar.php
+++ b/includes/class-gravityview-admin-bar.php
@@ -103,6 +103,7 @@ class GravityView_Admin_Bar {
 		$entry = gravityview()->request->is_entry();
 
 		if ( $entry && GVCommon::has_cap( array( 'gravityforms_edit_entries', 'gravityview_edit_entries' ), $entry->ID ) ) {
+			$entry_data = $entry->as_entry();
 
 			$wp_admin_bar->add_menu(
 				array(
@@ -112,7 +113,7 @@ class GravityView_Admin_Bar {
 					'meta'   => array(
 						'title' => sprintf( __( 'Edit Entry %s', 'gk-gravityview' ), $entry->get_slug() ),
 					),
-					'href'   => esc_url_raw( admin_url( sprintf( 'admin.php?page=gf_entries&amp;screen_mode=edit&amp;view=entry&amp;id=%d&lid=%d', $entry['form_id'], $entry['id'] ) ) ),
+					'href'   => esc_url_raw( admin_url( sprintf( 'admin.php?page=gf_entries&amp;screen_mode=edit&amp;view=entry&amp;id=%d&lid=%d', $entry_data['form_id'], $entry_data['id'] ) ) ),
 				)
 			);
 

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 #### 🚀 Added
 * New notification event "GravityView - Entry is duplicated" that runs when entries are duplicated using GravityView.
 
+#### Fixed
+* Edit Entry link in Admin bar was invalid for Multi Entries.
+
 #### ✨ Improved
 * Forms in the form selection filter on the Views page are now sorted alphabetically.
 


### PR DESCRIPTION
When using Multiple Forms (or anything that returns a `Multi_Entry` the admin-bar tries to get the `id` and `form_id` via the ArrayAccess methods; however, that doesn't work for the `Multi_Entry`. This PR addresses that by getting the entry as an array first.

`Multi_Entry` also did not have a valid `ID` which this PR also addresses.