### PR TITLE
Move gravityview header inside the container for layout builder

### DIFF
--- a/templates/views/gravityview-layout-builder.php
+++ b/templates/views/gravityview-layout-builder.php
@@ -15,11 +15,11 @@ if ( ! isset( $gravityview ) || empty( $gravityview->template ) ) {
 
 ob_start();
 gravityview_before( $gravityview );
-
-gravityview_header( $gravityview );
 ?>
 <div class="<?php echo esc_attr( gv_container_class( 'gv-layout-builder-container', false, $gravityview ) ); ?>">
 <?php
+gravityview_header( $gravityview );
+
 // There are no entries.
 if ( ! $gravityview->entries->count() ) {
 	?>


### PR DESCRIPTION
- Implements https://github.com/GravityKit/GravityView/issues/2328 and
https://github.com/GravityKit/GravityEdit/issues/270
- Move header inside the container like all other views to avoid current and future issues

