### PR TITLE
Release 2.39.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -238,12 +238,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:GravityKit/Foundation.git",
-                "reference": "49d64e0af95875a348d6928c5c6f7c60252a78ca"
+                "reference": "46f185dab850ab3beee94044ab521a8a4e140374"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GravityKit/Foundation/zipball/49d64e0af95875a348d6928c5c6f7c60252a78ca",
-                "reference": "49d64e0af95875a348d6928c5c6f7c60252a78ca",
+                "url": "https://api.github.com/repos/GravityKit/Foundation/zipball/46f185dab850ab3beee94044ab521a8a4e140374",
+                "reference": "46f185dab850ab3beee94044ab521a8a4e140374",
                 "shasum": ""
             },
             "require": {
@@ -341,10 +341,10 @@
                 }
             ],
             "support": {
-                "source": "https://github.com/GravityKit/Foundation/tree/v1.2.24",
+                "source": "https://github.com/GravityKit/Foundation/tree/develop",
                 "issues": "https://github.com/GravityKit/Foundation/issues"
             },
-            "time": "2025-04-24T20:54:03+00:00"
+            "time": "2025-04-25T20:25:58+00:00"
         },
         {
             "name": "illuminate/container",

--- a/composer.lock
+++ b/composer.lock
@@ -238,12 +238,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:GravityKit/Foundation.git",
-                "reference": "46f185dab850ab3beee94044ab521a8a4e140374"
+                "reference": "b69129c09143c417ed772c35e2b2c2671f72e1cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GravityKit/Foundation/zipball/46f185dab850ab3beee94044ab521a8a4e140374",
-                "reference": "46f185dab850ab3beee94044ab521a8a4e140374",
+                "url": "https://api.github.com/repos/GravityKit/Foundation/zipball/b69129c09143c417ed772c35e2b2c2671f72e1cc",
+                "reference": "b69129c09143c417ed772c35e2b2c2671f72e1cc",
                 "shasum": ""
             },
             "require": {
@@ -341,10 +341,10 @@
                 }
             ],
             "support": {
-                "source": "https://github.com/GravityKit/Foundation/tree/develop",
+                "source": "https://github.com/GravityKit/Foundation/tree/v1.2.25",
                 "issues": "https://github.com/GravityKit/Foundation/issues"
             },
-            "time": "2025-04-25T20:25:58+00:00"
+            "time": "2025-04-25T20:40:39+00:00"
         },
         {
             "name": "illuminate/container",

--- a/composer_public.json
+++ b/composer_public.json
@@ -21,9 +21,9 @@
       "type": "package",
       "package": {
         "name": "gravitykit/foundation",
-        "version": "1.2.24",
+        "version": "1.2.25",
         "dist": {
-          "url": "https://www.dropbox.com/scl/fi/bogp0p3bjydnlzajtye3f/foundation-1.2.24.zip?rlkey=vesk1v8bwrim2nrrrv99qyltt&dl=1",
+          "url": "https://www.dropbox.com/scl/fi/rxgwe4cm2oexyvw63n65q/foundation-1.2.25.zip?rlkey=dm0jwmvw9s5plst1z7gthnoue&dl=1",
           "type": "zip"
         }
       }

--- a/composer_public.json
+++ b/composer_public.json
@@ -21,9 +21,9 @@
       "type": "package",
       "package": {
         "name": "gravitykit/foundation",
-        "version": "1.2.23",
+        "version": "1.2.24",
         "dist": {
-          "url": "https://www.dropbox.com/scl/fi/mhitpaqbqp3pob9ihjz6b/foundation-1.2.23.zip?rlkey=drog8lyjxpttmfao0weskl57h&dl=1",
+          "url": "https://www.dropbox.com/scl/fi/bogp0p3bjydnlzajtye3f/foundation-1.2.24.zip?rlkey=vesk1v8bwrim2nrrrv99qyltt&dl=1",
           "type": "zip"
         }
       }

--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.39
+ * Version:             2.39.1
  * Requires PHP:        7.4.0
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
@@ -32,7 +32,7 @@ if ( ! GravityKit\GravityView\Foundation\meets_min_php_version_requirement( __FI
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.39' );
+define( 'GV_PLUGIN_VERSION', '2.39.1' );
 
 /**
  * Full path to the GravityView file

--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -297,6 +297,22 @@ class GravityView_Welcome {
 				 */
 				?>
 
+				<h3>2.39.1 on April 25, 2025</h3>
+
+				<p>This hotfix resolves a fatal error that occurred when updating the plugin from version 2.38 or earlier.</p>
+
+				<h4>🐛 Fixed</h4>
+
+				<ul>
+					<li>Fatal error when updating the plugin from version 2.38 or earlier.</li>
+				</ul>
+
+				<h4>🔧 Updated</h4>
+
+				<ul>
+					<li><a href="https://www.gravitykit.com/foundation/">Foundation</a> to version 1.2.25.</li>
+				</ul>
+
 				<h3>2.39 on April 24, 2025</h3>
 
 				<p>This update speeds up form loading in the View editor, fixes GravityEdit compatibility and translation issues in WordPress 6.8, and includes other fixes and improvements.</p>

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,16 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= 2.39.1 on April 25, 2025 =
+
+This hotfix resolves a fatal error that occurred when updating the plugin from version 2.38 or earlier.
+
+#### 🐛 Fixed
+* Fatal error when updating the plugin from version 2.38 or earlier.
+
+#### 🔧 Updated
+* [Foundation](https://www.gravitykit.com/foundation/) to version 1.2.25.
+
 = 2.39 on April 24, 2025 =
 
 This update speeds up form loading in the View editor, fixes GravityEdit compatibility and translation issues in WordPress 6.8, and includes other fixes and improvements.

--- a/translations.pot
+++ b/translations.pot
@@ -9,14 +9,13 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-04-24T22:46:28+00:00\n"
+"POT-Creation-Date: 2025-04-25T20:32:09+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.10.0\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: gk-gravityview\n"
 
 #. Plugin Name of the plugin
-#: gravityview.php
 #: future/includes/gutenberg/class-gv-gutenberg-blocks.php:165
 #: includes/class-gravityview-admin-bar.php:60
 #: includes/class-gravityview-roles-capabilities.php:149
@@ -26,17 +25,14 @@ msgstr ""
 
 #. Plugin URI of the plugin
 #. Author URI of the plugin
-#: gravityview.php
 msgid "https://www.gravitykit.com"
 msgstr ""
 
 #. Description of the plugin
-#: gravityview.php
 msgid "The best, easiest way to display Gravity Forms entries on your website."
 msgstr ""
 
 #. Author of the plugin
-#: gravityview.php
 #: vendor_prefixed/gravitykit/foundation/src/Licenses/WP/PluginsPage.php:409
 #: vendor_prefixed/gravitykit/foundation/src/WP/AdminMenu.php:198
 #: vendor_prefixed/gravitykit/foundation/src/WP/AdminMenu.php:199
@@ -7498,84 +7494,4 @@ msgstr ""
 #: future/includes/gutenberg/build/view.js:1
 #: future/includes/gutenberg/shared/js/sort-selector.js:75
 msgid "No Sorting Fields found"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-field/block.json
-msgctxt "block title"
-msgid "GravityView Entry Field"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-field/block.json
-msgctxt "block description"
-msgid "Display an entry field value."
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-field/block.json
-#: future/includes/gutenberg/blocks/entry-link/block.json
-#: future/includes/gutenberg/blocks/entry/block.json
-#: future/includes/gutenberg/blocks/view-details/block.json
-#: future/includes/gutenberg/blocks/view/block.json
-msgctxt "block keyword"
-msgid "GravityView"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-field/block.json
-#: future/includes/gutenberg/blocks/entry-link/block.json
-#: future/includes/gutenberg/blocks/entry/block.json
-#: future/includes/gutenberg/blocks/view-details/block.json
-msgctxt "block keyword"
-msgid "form entry"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-field/block.json
-#: future/includes/gutenberg/blocks/entry-link/block.json
-#: future/includes/gutenberg/blocks/entry/block.json
-#: future/includes/gutenberg/blocks/view-details/block.json
-msgctxt "block keyword"
-msgid "entry"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-link/block.json
-msgctxt "block title"
-msgid "GravityView Entry Link"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-link/block.json
-msgctxt "block description"
-msgid "Display a link to the GravityView entry."
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry/block.json
-msgctxt "block title"
-msgid "GravityView Entry"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry/block.json
-msgctxt "block description"
-msgid "Display a GravityView entry."
-msgstr ""
-
-#: future/includes/gutenberg/blocks/view-details/block.json
-msgctxt "block title"
-msgid "GravityView View Details"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/view-details/block.json
-msgctxt "block description"
-msgid "Display specific information about a GravityView View."
-msgstr ""
-
-#: future/includes/gutenberg/blocks/view/block.json
-msgctxt "block title"
-msgid "GravityView View"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/view/block.json
-msgctxt "block description"
-msgid "Display a GravityView View."
-msgstr ""
-
-#: future/includes/gutenberg/blocks/view/block.json
-msgctxt "block keyword"
-msgid "view"
 msgstr ""


### PR DESCRIPTION
This hotfix resolves a fatal error that occurred when updating the plugin from version 2.38 or earlier.

#### 🐛 Fixed
* Fatal error when updating the plugin from version 2.38 or earlier.

#### 🔧 Updated
* [Foundation](https://www.gravitykit.com/foundation/) to version 1.2.25.
