### PR TITLE
Adjust order of encoded space in file upload field

### DIFF
--- a/includes/fields/class-gravityview-field-fileupload.php
+++ b/includes/fields/class-gravityview-field-fileupload.php
@@ -477,9 +477,6 @@ class GravityView_Field_FileUpload extends GravityView_Field {
 			$file_path = set_url_scheme( $file_path );
 		}
 
-		// This is from Gravity Forms's code
-		$file_path = esc_attr( str_replace( ' ', '%20', $file_path ) );
-
 		// Get file path information
 		$file_path_info = pathinfo( $file_path );
 
@@ -500,8 +497,8 @@ class GravityView_Field_FileUpload extends GravityView_Field {
 
 		// Get the secure download URL
 		$is_secure          = false;
-		$insecure_file_path = $file_path;
-		$secure_file_path   = $field->get_download_url( $file_path );
+		$insecure_file_path = str_replace( ' ', '%20', $file_path );
+		$secure_file_path   = str_replace( ' ', '%20', $field->get_download_url( $file_path ) );
 
 		if ( $secure_file_path !== $file_path ) {
 			$file_path = $secure_file_path;


### PR DESCRIPTION
Resolve a bug where filenames with spaces are not correctly encoded when run through `$field->get_download_url()`, causing the filename and link to break.

**BEFORE**
![CleanShot 2025-05-05 at 05 56 24@2x](https://github.com/user-attachments/assets/c21217c3-a6b7-4170-b554-ed773a0f3a50)

**AFTER**
![CleanShot 2025-05-05 at 05 56 57@2x](https://github.com/user-attachments/assets/19f0f667-6d72-46d1-8325-5031987ad685)

By adjusting the space character encoding until after the URL is secured the file can now be viewed and downloaded.

Note: Gravity Forms auto-removes spaces from filenames when files are uploaded via traditional means. To replicate this bug you need to use manually added the file to the correct directory and use `GFAPI::create_entry()`.
