### PR TITLE
Add a common framework for supporting third-party endpoints

### DIFF
--- a/includes/load-plugin-and-theme-hooks.php
+++ b/includes/load-plugin-and-theme-hooks.php
@@ -16,9 +16,10 @@
 $include_path = GRAVITYVIEW_DIR . 'includes/plugin-and-theme-hooks/';
 
 // Abstract class
-require $include_path . 'abstract-gravityview-plugin-and-theme-hooks.php';
-require $include_path . 'class-gravityview-object-placeholder.php';
-require $include_path . 'class-gravityview-feature-upgrade.php';
+require_once $include_path . 'abstract-gravityview-plugin-and-theme-hooks.php';
+require_once $include_path . 'class-gravityview-object-placeholder.php';
+require_once $include_path . 'class-gravityview-feature-upgrade.php';
+require_once $include_path . 'trait-gravityview-permalink-override.php';
 
 $plugin_hooks_files = glob( $include_path . 'class-gravityview-plugin-hooks-*.php' );
 

--- a/includes/plugin-and-theme-hooks/abstract-gravityview-plugin-and-theme-hooks.php
+++ b/includes/plugin-and-theme-hooks/abstract-gravityview-plugin-and-theme-hooks.php
@@ -176,6 +176,8 @@ abstract class GravityView_Plugin_and_Theme_Hooks {
 		if ( $this->post_type_support ) {
 			add_filter( 'gravityview_post_type_support', array( $this, 'merge_post_type_support' ), 10, 2 );
 		}
+
+		add_action( 'template_redirect', [ $this, 'on_template_redirect' ] );
 	}
 
 	/**
@@ -248,5 +250,39 @@ abstract class GravityView_Plugin_and_Theme_Hooks {
 	 */
 	public function merge_content_meta_keys( $meta_keys = array(), $post = null, &$views = null ) {
 		return array_merge( $this->content_meta_keys, $meta_keys );
+	}
+
+	/**
+	 * Add hooks to remove the permalink structure from View rendered links.
+	 *
+	 * @since TODO
+	 *
+	 * @return void
+	 */
+	public function on_template_redirect() {
+		if ( ! $this->should_disable_permalink_structure() ) {
+			return;
+		}
+
+		add_action( 'gravityview/template/before', function() {
+			add_filter( 'option_permalink_structure', '__return_false' );
+		}, 1 );
+
+		add_action( 'gravityview/template/after', function() {
+			remove_filter( 'option_permalink_structure', '__return_false' );
+		}, 1000 );
+	}
+
+	/**
+	 * When returning true, Views will be rendered with permalinks disabled.
+	 *
+	 * This is useful for plugins with custom endpoints, such as LearnDash, BuddyBoss, etc.
+	 *
+	 * @since TODO
+	 *
+	 * @return bool Whether to remove the permalink structure from View rendered links.
+	 */
+	public function should_disable_permalink_structure() {
+		return false;
 	}
 }

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-buddypress.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-buddypress.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Improve compatibility with BuddyPress.
+ *
+ * @file      class-gravityview-plugin-hooks-buddypress.php
+ * @package   GravityView
+ * @license   GPL2+
+ * @author    GravityKit <hello@gravitykit.com>
+ * @link      http://www.gravitykit.com
+ * @copyright Copyright 2015, Katz Web Services, Inc.
+ *
+ * @since 1.15.2
+ */
+
+/**
+ * @inheritDoc
+ */
+class GravityView_Plugin_Hooks_BuddyPress extends GravityView_Plugin_and_Theme_Hooks {
+
+	/**
+	 * The function name to check if we are on a BuddyPress page.
+	 *
+	 * @since TODO
+	 *
+	 * @var string
+	 */
+	protected $function_name = 'bp_is_user_profile';
+
+	/**
+	 * Remove the permalink structure for BuddyPress pages.
+	 *
+	 * @since TODO
+	 *
+	 * @return bool Whether to remove the permalink structure from View rendered links.
+	 */
+	public function should_disable_permalink_structure() {
+
+		if ( ! bp_is_user_profile() ) {
+			return parent::should_disable_permalink_structure();
+		}
+
+		return true;
+	}
+
+	/**
+	 * Modify the edit link for BuddyPress profile pages.
+	 *
+	 * Needs to run on template_redirect to ensure that $post is set for
+	 *
+	 * @since TODO
+	 *
+	 * @return void
+	 */
+	public function on_template_redirect() {
+
+		if ( ! bp_is_user_profile() ) {
+			return;
+		}
+
+		/**
+		* Make sure that GravityView "sees" that we're in an entry.
+		*
+		* @see \GV\Request::is_entry()
+		*/
+		add_filter( 'gravityview/edit/link', [ $this, 'edit_link_filter' ], 10, 2 );
+
+		parent::on_template_redirect();
+	}
+
+	/**
+	 * Modify the edit link for BuddyPress profile pages.
+	 *
+	 * @since TODO
+	 *
+	 * @return void
+	 */
+	public function edit_link_filter( $url, $entry ) {
+		$entry = \GV\GF_Entry::by_id( $entry['id'] );
+
+		if( ! $entry ) {
+			return $url;
+		}
+
+		$endpoint = \GV\Entry::get_endpoint_name();
+
+		$query_args = self::get_query_args( $url );
+
+		$query_args[ $endpoint ] = $entry->get_slug( true );
+
+		$current_url = add_query_arg( [] );
+
+		return add_query_arg( $query_args, $current_url );
+	}
+
+	/**
+	 * Get the query args from the current URL.
+	 *
+	 * @since TODO
+	 *
+	 * @param string $url The URL to get the query args from.
+	 *
+	 * @return array
+	 */
+	static private function get_query_args( $url ) {
+		$parsed_url = wp_parse_url( $url );
+
+		$query_args = [];
+		if ( ! empty( $parsed_url['query'] ) ) {
+			parse_str( $parsed_url['query'], $query_args );
+		}
+
+		return $query_args;
+	}
+}
+
+new GravityView_Plugin_Hooks_BuddyPress();

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-buddypress.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-buddypress.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Improve compatibility with BuddyPress.
+ * Improve compatibility with BuddyPress and BuddyBoss.
  *
  * @file      class-gravityview-plugin-hooks-buddypress.php
  * @package   GravityView
  * @license   GPL2+
  * @author    GravityKit <hello@gravitykit.com>
  * @link      http://www.gravitykit.com
- * @copyright Copyright 2015, Katz Web Services, Inc.
+ * @copyright Copyright 2025, Katz Web Services, Inc.
  *
- * @since 1.15.2
+ * @since TODO
  */
 
 /**
@@ -17,8 +17,10 @@
  */
 class GravityView_Plugin_Hooks_BuddyPress extends GravityView_Plugin_and_Theme_Hooks {
 
+	use GravityView_Permalink_Override_Trait;
+
 	/**
-	 * The function name to check if we are on a BuddyPress page.
+	 * The function name to check if we are on a BuddyPress/Boss page.
 	 *
 	 * @since TODO
 	 *
@@ -33,83 +35,13 @@ class GravityView_Plugin_Hooks_BuddyPress extends GravityView_Plugin_and_Theme_H
 	 *
 	 * @return bool Whether to remove the permalink structure from View rendered links.
 	 */
-	public function should_disable_permalink_structure() {
+	protected function should_disable_permalink_structure() {
 
 		if ( ! bp_is_user_profile() ) {
-			return parent::should_disable_permalink_structure();
+			return false;
 		}
 
 		return true;
-	}
-
-	/**
-	 * Modify the edit link for BuddyPress profile pages.
-	 *
-	 * Needs to run on template_redirect to ensure that $post is set for
-	 *
-	 * @since TODO
-	 *
-	 * @return void
-	 */
-	public function on_template_redirect() {
-
-		if ( ! bp_is_user_profile() ) {
-			return;
-		}
-
-		/**
-		* Make sure that GravityView "sees" that we're in an entry.
-		*
-		* @see \GV\Request::is_entry()
-		*/
-		add_filter( 'gravityview/edit/link', [ $this, 'edit_link_filter' ], 10, 2 );
-
-		parent::on_template_redirect();
-	}
-
-	/**
-	 * Modify the edit link for BuddyPress profile pages.
-	 *
-	 * @since TODO
-	 *
-	 * @return void
-	 */
-	public function edit_link_filter( $url, $entry ) {
-		$entry = \GV\GF_Entry::by_id( $entry['id'] );
-
-		if( ! $entry ) {
-			return $url;
-		}
-
-		$endpoint = \GV\Entry::get_endpoint_name();
-
-		$query_args = self::get_query_args( $url );
-
-		$query_args[ $endpoint ] = $entry->get_slug( true );
-
-		$current_url = add_query_arg( [] );
-
-		return add_query_arg( $query_args, $current_url );
-	}
-
-	/**
-	 * Get the query args from the current URL.
-	 *
-	 * @since TODO
-	 *
-	 * @param string $url The URL to get the query args from.
-	 *
-	 * @return array
-	 */
-	static private function get_query_args( $url ) {
-		$parsed_url = wp_parse_url( $url );
-
-		$query_args = [];
-		if ( ! empty( $parsed_url['query'] ) ) {
-			parse_str( $parsed_url['query'], $query_args );
-		}
-
-		return $query_args;
 	}
 }
 

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-learndash.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-learndash.php
@@ -1,17 +1,22 @@
 <?php
 /**
- * Add GravityView integration to LifterLMS.
+ * Add GravityView integration to LearnDash.
  *
- * @file      class-gravityview-plugin-hooks-lifterlms.php
+ * @file      class-gravityview-plugin-hooks-learndash.php
  * @since     2.20
  * @license   GPL2+
  * @author    Katz Web Services, Inc.
  * @link      https://gravityview.co
- * @copyright Copyright 2024, Katz Web Services, Inc.
+ * @copyright Copyright 2025, Katz Web Services, Inc.
  *
  * @package   GravityView
  */
 
+/**
+ * Class GravityView_Plugin_Hooks_LearnDash
+ *
+ * @since TODO
+ */
 final class GravityView_Plugin_Hooks_LearnDash extends GravityView_Plugin_and_Theme_Hooks {
 
 	/**

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-learndash.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-learndash.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Add GravityView integration to LifterLMS.
+ *
+ * @file      class-gravityview-plugin-hooks-lifterlms.php
+ * @since     2.20
+ * @license   GPL2+
+ * @author    Katz Web Services, Inc.
+ * @link      https://gravityview.co
+ * @copyright Copyright 2024, Katz Web Services, Inc.
+ *
+ * @package   GravityView
+ */
+
+final class GravityView_Plugin_Hooks_LearnDash extends GravityView_Plugin_and_Theme_Hooks {
+
+	/**
+	 * The constant name for the LearnDash version.
+	 *
+	 * @var string
+	 */
+	protected $constant_name = 'LEARNDASH_VERSION';
+
+	/**
+	 * The function name to fetch LearnDash post types.
+	 *
+	 * @var string
+	 */
+	protected $function_name = 'learndash_get_post_types';
+
+	/**
+	 * Remove the permalink structure for LearnDash post types.
+	 *
+	 * @since TODO
+	 *
+	 * @return bool Whether to remove the permalink structure from View rendered links.
+	 */
+	public function should_disable_permalink_structure() {
+		// The current page is not a LearnDash post type.
+		if ( ! in_array( get_post_type(), learndash_get_post_types(), true ) ) {
+			return parent::should_disable_permalink_structure();
+		}
+
+		return true;
+	}
+}
+
+new GravityView_Plugin_Hooks_LearnDash();

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-learndash.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-learndash.php
@@ -15,6 +15,17 @@
 final class GravityView_Plugin_Hooks_LearnDash extends GravityView_Plugin_and_Theme_Hooks {
 
 	/**
+	 * Use the permalink override trait. Alias it so that we can call the trait's method first.
+	 *
+	 * @since TODO
+	 *
+	 * @var GravityView_Permalink_Override_Trait
+	 */
+	use GravityView_Permalink_Override_Trait {
+		GravityView_Permalink_Override_Trait::on_template_redirect as trait_on_template_redirect;
+	}
+
+	/**
 	 * The constant name for the LearnDash version.
 	 *
 	 * @var string
@@ -29,19 +40,55 @@ final class GravityView_Plugin_Hooks_LearnDash extends GravityView_Plugin_and_Th
 	protected $function_name = 'learndash_get_post_types';
 
 	/**
+	 * Check if the current post type is a LearnDash post type.
+	 *
+	 * @since TODO
+	 *
+	 * @return bool Whether the current post type is a LearnDash post type.
+	 */
+	private function is_learndash_post_type() {
+		return in_array( get_post_type(), learndash_get_post_types(), true );
+	}
+
+	/**
 	 * Remove the permalink structure for LearnDash post types.
 	 *
 	 * @since TODO
 	 *
 	 * @return bool Whether to remove the permalink structure from View rendered links.
 	 */
-	public function should_disable_permalink_structure() {
+	protected function should_disable_permalink_structure() {
 		// The current page is not a LearnDash post type.
-		if ( ! in_array( get_post_type(), learndash_get_post_types(), true ) ) {
-			return parent::should_disable_permalink_structure();
+		if ( ! $this->is_learndash_post_type() ) {
+			return false;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Handle template redirect for LearnDash integration.
+	 *
+	 * Extends the trait functionality to also remove the single entry title filter.
+	 *
+	 * @since TODO
+	 *
+	 * @return void
+	 */
+	public function on_template_redirect() {
+
+		// Call the trait's method first.
+		$this->trait_on_template_redirect();
+
+		// Add LearnDash-specific logic.
+		if ( ! $this->is_learndash_post_type() ) {
+			return;
+		}
+
+		// Don't change the title of the single entry page for LearnDash posts.
+		if ( gravityview()->request->is_entry() ) {
+			remove_filter( 'the_title', array( GravityView_frontend::getInstance(), 'single_entry_title' ), 1, 2 );
+		}
 	}
 }
 

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-ultimate-member.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-ultimate-member.php
@@ -18,6 +18,8 @@
  */
 class GravityView_Theme_Hooks_Ultimate_Member extends GravityView_Plugin_and_Theme_Hooks {
 
+	use GravityView_Permalink_Override_Trait;
+
 	/**
 	 * @inheritDoc
 	 * @since 1.17.2
@@ -47,12 +49,12 @@ class GravityView_Theme_Hooks_Ultimate_Member extends GravityView_Plugin_and_The
 	 *
 	 * @return bool Whether to remove the permalink structure from View rendered links.
 	 */
-	public function should_disable_permalink_structure() {
+	protected function should_disable_permalink_structure() {
 		if ( um_is_core_page( 'user' ) || um_is_core_page( 'members' ) ) {
 			return true;
 		}
 
-		return parent::should_disable_permalink_structure();
+		return false;
 	}
 
 	/**

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-ultimate-member.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-ultimate-member.php
@@ -24,11 +24,35 @@ class GravityView_Theme_Hooks_Ultimate_Member extends GravityView_Plugin_and_The
 	 */
 	protected $constant_name = 'ultimatemember_version';
 
+	/**
+	 * The function name to check if we are on a UM Core Page.
+	 *
+	 * @since TODO
+	 *
+	 * @var string
+	 */
+	protected $function_name = 'um_is_core_page';
+
 	function add_hooks() {
 		parent::add_hooks();
 
 		// Needs to be early to be triggered before DataTables
 		add_action( 'template_redirect', array( $this, 'parse_um_profile_post_content' ) );
+	}
+
+	/**
+	 * Remove the permalink structure for Ultimate Member profile tabs.
+	 *
+	 * @since TODO
+	 *
+	 * @return bool Whether to remove the permalink structure from View rendered links.
+	 */
+	public function should_disable_permalink_structure() {
+		if ( um_is_core_page( 'user' ) || um_is_core_page( 'members' ) ) {
+			return true;
+		}
+
+		return parent::should_disable_permalink_structure();
 	}
 
 	/**

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-woocommerce.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-woocommerce.php
@@ -18,12 +18,39 @@
 class GravityView_Plugin_Hooks_WooCommerce extends GravityView_Plugin_and_Theme_Hooks {
 
 	/**
+	 * The function name to fetch WooCommerce page IDs.
+	 *
+	 * @since TODO
+	 *
+	 * @var string
+	 */
+	protected $function_name = 'wc_get_page_id';
+
+	/**
 	 * @inheritDoc
 	 */
 	protected $style_handles = array(
 		'woocommerce_admin_menu_styles',
 		'woocommerce_admin_styles',
 	);
+
+	/**
+	 * Remove the permalink structure for LearnDash post types.
+	 *
+	 * @since TODO
+	 *
+	 * @return bool Whether to remove the permalink structure from View rendered links.
+	 */
+	public function should_disable_permalink_structure() {
+
+		$page_id = wc_get_page_id( 'myaccount' );
+
+		if ( get_the_ID() !== $page_id ) {
+			return parent::should_disable_permalink_structure();
+		}
+
+		return true;
+	}
 }
 
 new GravityView_Plugin_Hooks_WooCommerce();

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-woocommerce.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-woocommerce.php
@@ -17,6 +17,8 @@
  */
 class GravityView_Plugin_Hooks_WooCommerce extends GravityView_Plugin_and_Theme_Hooks {
 
+	use GravityView_Permalink_Override_Trait;
+
 	/**
 	 * The function name to fetch WooCommerce page IDs.
 	 *
@@ -41,12 +43,11 @@ class GravityView_Plugin_Hooks_WooCommerce extends GravityView_Plugin_and_Theme_
 	 *
 	 * @return bool Whether to remove the permalink structure from View rendered links.
 	 */
-	public function should_disable_permalink_structure() {
-
+	protected function should_disable_permalink_structure() {
 		$page_id = wc_get_page_id( 'myaccount' );
 
 		if ( get_the_ID() !== $page_id ) {
-			return parent::should_disable_permalink_structure();
+			return false;
 		}
 
 		return true;

--- a/includes/plugin-and-theme-hooks/trait-gravityview-permalink-override.php
+++ b/includes/plugin-and-theme-hooks/trait-gravityview-permalink-override.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Trait for handling permalink structure overrides in plugin and theme integrations.
+ *
+ * This trait provides functionality to disable WordPress permalinks and override
+ * directory links when rendering GravityView templates. It's useful for plugins
+ * with custom endpoints (like LearnDash, BuddyPress, etc.) that need special
+ * URL handling to render GravityView properly.
+ *
+ * @file      trait-gravityview-permalink-override.php
+ * @package   GravityView
+ * @license   GPL2+
+ * @author    GravityKit <hello@gravitykit.com>
+ * @link      https://www.gravitykit.com
+ * @copyright Copyright 2025, Katz Web Services, Inc.
+ *
+ * @since TODO
+ */
+
+/**
+ * Trait for permalink structure override functionality.
+ *
+ * Classes using this trait must implement the should_disable_permalink_structure() method
+ * to determine when permalink overrides should be applied. The abstract class will automatically
+ * detect classes using this trait and set up the necessary hooks.
+ *
+ * @since TODO
+ */
+trait GravityView_Permalink_Override_Trait {
+
+	/**
+	 * Handle template redirect to set up permalink overrides if needed.
+	 *
+	 * This is running on the `template_redirect` action so that $post is set up.
+	 *
+	 * @since TODO
+	 *
+	 * @return void
+	 */
+	public function on_template_redirect() {
+		if ( ! $this->should_disable_permalink_structure() ) {
+			return;
+		}
+
+		// Remove the entry endpoint from the back link.
+		add_filter( 'gravityview/template/links/back/url', [ $this, 'remove_entry_endpoint_from_back_link' ] );
+
+		// Add hooks before template renders
+		add_action( 'gravityview/template/before', [ $this, 'disable_permalinks_before_template' ], 1 );
+
+		// Remove hooks after template renders
+		add_action( 'gravityview/template/after', [ $this, 'restore_permalinks_after_template' ], 1000 );
+	}
+
+	/**
+	 * Remove the entry endpoint from the back link URL.
+	 *
+	 * @since TODO
+	 *
+	 * @return string The URL with entry endpoint removed.
+	 */
+	public function remove_entry_endpoint_from_back_link() {
+		return remove_query_arg( \GV\Entry::get_endpoint_name() );
+	}
+
+	/**
+	 * Get the base URL for directory links without query args.
+	 *
+	 * @since TODO
+	 *
+	 * @return string The base site URL without GravityView query args.
+	 */
+	public function get_base_url_without_query_args() {
+		return site_url( remove_query_arg( gv_get_query_args(), add_query_arg( [] ) ) );
+	}
+
+	/**
+	 * Disable permalinks and override directory links before template renders.
+	 *
+	 * @since TODO
+	 *
+	 * @return void
+	 */
+	public function disable_permalinks_before_template() {
+		add_filter( 'option_permalink_structure', '__return_false' );
+		add_filter( 'gravityview_directory_link', [ $this, 'get_base_url_without_query_args' ] );
+		add_filter( 'gravityview/view/links/directory', [ $this, 'get_base_url_without_query_args' ] );
+		add_filter( 'gravityview/widget/search/form/action', [ $this, 'get_base_url_without_query_args' ] );
+	}
+
+	/**
+	 * Restore permalink structure and remove directory link overrides after template renders.
+	 *
+	 * @since TODO
+	 *
+	 * @return void
+	 */
+	public function restore_permalinks_after_template() {
+		remove_filter( 'option_permalink_structure', '__return_false' );
+		remove_filter( 'gravityview_directory_link', [ $this, 'get_base_url_without_query_args' ] );
+		remove_filter( 'gravityview/view/links/directory', [ $this, 'get_base_url_without_query_args' ] );
+		remove_filter( 'gravityview/widget/search/form/action', [ $this, 'get_base_url_without_query_args' ] );
+	}
+
+	/**
+	 * Determine whether permalinks should be disabled for View rendering.
+	 *
+	 * This method must be implemented by classes using this trait.
+	 * Return true to disable permalinks and use the override functionality.
+	 *
+	 * @since TODO
+	 *
+	 * @return bool Whether to remove the permalink structure from View rendered links.
+	 */
+	abstract protected function should_disable_permalink_structure();
+}

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 #### 🐛 Fixed
 
 * For some users, adding a Chained Selects Add-On field to the Search Bar causes JavaScript code to be visible and the field would not work as expected.
+* Single Entry and Edit Entry were not working when Views were embedded in some plugin membership pages. These plugins include LearnDash, BuddyBoss and BuddyPress, Ultimate Member, and WooCommerce Account Pages.
 
 #### 💻 Developer Updates
 


### PR DESCRIPTION
This fixes issues where single entry and edit entry links weren't properly rendering in LearnDash, BuddyPress, BuddyBoss, WooCommerce Account Tabs, and Ultimate Member.

Resolves #1931 

Before: 

- Entry links may or may not work, with format of example.com/my-account/page/entry/123/
- Edit Entry links did not work, with format of `example.com/my-account/page/entry/123/?edit=dasdsad&gvid=567`

After:

- Entry links work, with format of `example.com/my-account/page/entry/123/?entry=123`
- Edit Entry work, with format of `example.com/my-account/page/entry/123/?edit=dasdsad&gvid=567&entry=123`

Note that `entry=123` is appended.

@Mwalek to test, 

- Install and activate WooCommerce
- Set up account page landing page (`my-account` is default, I believe)
- Install WooCommerce Account Pages (contact me; I'll share with you)
- Activate the plugin, create a new Page, set the page parent as the new My Account page
- Add a GravityView View there, with Edit Entry and Link to Entry links

## Things to test

- A View should render
- Edit Entry and Link to Entry links should both work on multiple entry pages
- Edit Entry links should work on Single Entry pages
- All other GravityView shortcodes should work (`[gv_entry_link]`, for example)
- View Entry in Lightbox setting should still work
- Search bar URL should use the account page (or whatever membership page) as the base URL
- Back link works properly
- Cancel button in edit entry
- Editing entries saves properly

This should work when:

- [ ] Custom slugs are enabled using `add_filter( 'gravityview_custom_entry_slug', '__return_true' );`
- [ ] Using DataTables layout

💾 [Build file](https://www.dropbox.com/scl/fi/nhzapbntqg10i00ypk13d/gravityview-2.40-584929a73.zip?rlkey=qiw7har4uw0k10xl3n8fhxl54&dl=1) (584929a73).