### PR TITLE
Prevent JSON from appearing when rendering block

### DIFF
--- a/future/includes/gutenberg/blocks/entry-field/block.php
+++ b/future/includes/gutenberg/blocks/entry-field/block.php
@@ -4,6 +4,7 @@ namespace GravityKit\GravityView\Gutenberg\Blocks;
 
 use GravityKit\GravityView\Gutenberg\Blocks;
 use GravityKit\GravityView\Foundation\Helpers\Arr;
+use GVCommon;
 
 class EntryField {
 	/**
@@ -45,13 +46,15 @@ class EntryField {
 			'fieldSettingOverrides' => 'field_setting_overrides',
 		);
 
+		$is_rest_request = GVCommon::is_rest_request();
+
 		$shortcode_attributes = array();
 
 		foreach ( $block_attributes as $attribute => $value ) {
 			$value = esc_attr( sanitize_text_field( $value ) );
 
 			if ( isset( $block_to_shortcode_attributes_map[ $attribute ] ) && ! empty( $value ) ) {
-				if ( 'secret' === $attribute && Arr::get( $block_attributes, 'previewAsShortcode' ) ) {
+				if ( 'secret' === $attribute && Arr::get( $block_attributes, 'previewAsShortcode' ) && $is_rest_request ) {
 					$value = '*********';
 				}
 
@@ -69,7 +72,7 @@ class EntryField {
 
 		$shortcode = sprintf( '[gvfield %s]', implode( ' ', $shortcode_attributes ) );
 
-		if ( Arr::get( $block_attributes, 'previewAsShortcode' ) ) {
+		if ( Arr::get( $block_attributes, 'previewAsShortcode' ) && $is_rest_request ) {
 			return $shortcode;
 		}
 

--- a/future/includes/gutenberg/blocks/entry-link/block.php
+++ b/future/includes/gutenberg/blocks/entry-link/block.php
@@ -4,6 +4,7 @@ namespace GravityKit\GravityView\Gutenberg\Blocks;
 
 use GravityKit\GravityView\Gutenberg\Blocks;
 use GravityKit\GravityView\Foundation\Helpers\Arr;
+use GVCommon;
 
 class EntryLink {
 	/**
@@ -72,11 +73,13 @@ class EntryLink {
 			$shortcode = sprintf( '[gv_entry_link %s/]', implode( ' ', $shortcode_attributes ) );
 		}
 
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		$is_rest_request = GVCommon::is_rest_request();
+
+		if ( $is_rest_request ) {
 			add_filter( 'gravityview/entry_link/add_query_args', '__return_false' );
 		}
 
-		if ( Arr::get( $block_attributes, 'previewAsShortcode' ) ) {
+		if ( Arr::get( $block_attributes, 'previewAsShortcode' ) && $is_rest_request ) {
 			return $shortcode;
 		}
 

--- a/future/includes/gutenberg/blocks/entry/block.php
+++ b/future/includes/gutenberg/blocks/entry/block.php
@@ -4,6 +4,7 @@ namespace GravityKit\GravityView\Gutenberg\Blocks;
 
 use GravityKit\GravityView\Gutenberg\Blocks;
 use GravityKit\GravityView\Foundation\Helpers\Arr;
+use GVCommon;
 
 class Entry {
 	/**
@@ -43,13 +44,16 @@ class Entry {
 			'secret'  => 'secret',
 		);
 
+		$preview_as_shortcode = Arr::get( $block_attributes, 'previewAsShortcode' );
+		$is_rest_request      = GVCommon::is_rest_request();
+
 		$shortcode_attributes = array();
 
 		foreach ( $block_attributes as $attribute => $value ) {
 			$value = esc_attr( sanitize_text_field( $value ) );
 
 			if ( isset( $block_to_shortcode_attributes_map[ $attribute ] ) && ! empty( $value ) ) {
-				if ( 'secret' === $attribute && Arr::get( $block_attributes, 'previewAsShortcode' ) ) {
+				if ( 'secret' === $attribute && $preview_as_shortcode && $is_rest_request ) {
 					$value = '*********';
 				}
 
@@ -63,7 +67,7 @@ class Entry {
 
 		$shortcode = sprintf( '[gventry %s]', implode( ' ', $shortcode_attributes ) );
 
-		if ( Arr::get( $block_attributes, 'previewAsShortcode' ) ) {
+		if ( $preview_as_shortcode && $is_rest_request ) {
 			return $shortcode;
 		}
 

--- a/future/includes/gutenberg/blocks/view-details/block.php
+++ b/future/includes/gutenberg/blocks/view-details/block.php
@@ -4,6 +4,7 @@ namespace GravityKit\GravityView\Gutenberg\Blocks;
 
 use GravityKit\GravityView\Gutenberg\Blocks;
 use GravityKit\GravityView\Foundation\Helpers\Arr;
+use GVCommon;
 
 class ViewDetails {
 	/**
@@ -43,13 +44,16 @@ class ViewDetails {
 			'secret' => 'secret',
 		);
 
+		$preview_as_shortcode = Arr::get( $block_attributes, 'previewAsShortcode' );
+		$is_rest_request      = GVCommon::is_rest_request();
+
 		$shortcode_attributes = array();
 
 		foreach ( $block_attributes as $attribute => $value ) {
 			$value = esc_attr( sanitize_text_field( $value ) );
 
 			if ( isset( $block_to_shortcode_attributes_map[ $attribute ] ) && ! empty( $value ) ) {
-				if ( 'secret' === $attribute && Arr::get( $block_attributes, 'previewAsShortcode' ) ) {
+				if ( 'secret' === $attribute && $preview_as_shortcode && $is_rest_request ) {
 					$value = '*********';
 				}
 
@@ -63,7 +67,7 @@ class ViewDetails {
 
 		$shortcode = sprintf( '[gravityview %s]', implode( ' ', $shortcode_attributes ) );
 
-		if ( Arr::get( $block_attributes, 'previewAsShortcode' ) ) {
+		if ( $preview_as_shortcode && $is_rest_request ) {
 			return $shortcode;
 		}
 

--- a/future/includes/gutenberg/blocks/view/block.php
+++ b/future/includes/gutenberg/blocks/view/block.php
@@ -4,7 +4,7 @@ namespace GravityKit\GravityView\Gutenberg\Blocks;
 
 use GravityKit\GravityView\Gutenberg\Blocks;
 use GravityKit\GravityView\Foundation\Helpers\Arr;
-use GFFormDisplay;
+use GVCommon;
 
 class View {
 	/**
@@ -41,13 +41,16 @@ class View {
 		$shortcode_attributes        = [];
 		$mapped_shortcode_attributes = \GV\Shortcodes\gravityview::map_block_atts_to_shortcode_atts( $block_attributes );
 
+		$preview_as_shortcode = Arr::get( $block_attributes, 'previewAsShortcode' );
+		$is_rest_request      = GVCommon::is_rest_request();
+
 		foreach ( $mapped_shortcode_attributes as $attribute => $value ) {
 			$value = esc_attr( sanitize_text_field( $value ) );
 			if ( empty( $value ) ) {
 				continue;
 			}
 
-			if ( 'secret' === $attribute && $preview_as_shortcode ) {
+			if ( 'secret' === $attribute && $preview_as_shortcode && $is_rest_request ) {
 				$value = '*********';
 			}
 
@@ -60,7 +63,7 @@ class View {
 
 		$shortcode = sprintf( '[gravityview %s]', implode( ' ', $shortcode_attributes ) );
 
-		if ( Arr::get( $block_attributes, 'previewAsShortcode' ) ) {
+		if ( $preview_as_shortcode && $is_rest_request ) {
 			return wp_json_encode(
 				array(
 					'content' => $shortcode,
@@ -72,7 +75,7 @@ class View {
 
 		$rendered_shortcode = Blocks::render_shortcode( $shortcode );
 
-		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+		if ( ! $is_rest_request ) {
 			return $rendered_shortcode['content'];
 		}
 

--- a/future/includes/gutenberg/blocks/view/block.php
+++ b/future/includes/gutenberg/blocks/view/block.php
@@ -47,6 +47,10 @@ class View {
 				continue;
 			}
 
+			if ( 'secret' === $attribute && $preview_as_shortcode ) {
+				$value = '*********';
+			}
+
 			$shortcode_attributes[] = sprintf(
 				'%s="%s"',
 				$attribute,

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -2124,7 +2124,18 @@ class GVCommon {
 		// Optional: $from_name, $message_format, $attachments, $lead, $notification
 		$SendEmail->invoke( new GFCommon(), $from, $to, $bcc, $reply_to, $subject, $message, $from_name, $message_format, $attachments, $entry, $notification );
 	}
-}//end class
+
+	/**
+	 * Check if the current request is a REST request.
+	 *
+	 * @since TODO
+	 *
+	 * @return bool True if the request is a REST request, false otherwise.
+	 */
+	public static function is_rest_request() {
+		return defined( 'REST_REQUEST' ) && REST_REQUEST;
+	}
+}
 
 
 /**

--- a/includes/wordpress-widgets/class-gravityview-recent-entries-widget.php
+++ b/includes/wordpress-widgets/class-gravityview-recent-entries-widget.php
@@ -100,7 +100,7 @@ class GravityView_Recent_Entries_Widget extends WP_Widget {
 			return;
 		}
 
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		if ( GVCommon::is_rest_request() ) {
 			return false;
 		}
 

--- a/includes/wordpress-widgets/class-gravityview-search-wp-widget.php
+++ b/includes/wordpress-widgets/class-gravityview-search-wp-widget.php
@@ -53,7 +53,7 @@ class GravityView_Search_WP_Widget extends WP_Widget {
 
 	public function widget( $args, $instance ) {
 
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		if ( GVCommon::is_rest_request() ) {
 			return false;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -30,10 +30,12 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 #### 🐛 Fixed
 
 * For some users, adding a Chained Selects Add-On field to the Search Bar causes JavaScript code to be visible and the field would not work as expected.
+* When "Preview as shortcode" was enabled in the View editor, some blocks would not render properly on the frontend.
 
 #### 💻 Developer Updates
 
 * `requires` and `requires-not` field setting conditional display were not working correctly for radio buttons.
+* Added `GVCommon::is_rest_request()` method to check if the current request is a REST request, a clone of the `wp_is_serving_rest_request()` function.
 
 #### 🔧 Updated
 


### PR DESCRIPTION
When "Preview as shortcode" was enabled in the View editor, some blocks would render improperly on the frontend, showing JSON instead of block content.

Resolves #2357 

💾 [Build file](https://www.dropbox.com/scl/fi/nmr9jf4jugia6nfurwt7x/gravityview-2.40-4114a353c.zip?rlkey=mh15nrjakm2cyppbgah5lwdq0&dl=1) (4114a353c).