### PR TITLE
[WIP] Feature/2280 add a warning related to unwanted behaviors of the search everything option on the search bar

### DIFF
--- a/future/includes/class-gv-settings-view.php
+++ b/future/includes/class-gv-settings-view.php
@@ -101,6 +101,13 @@ class View_Settings extends Settings {
 						'url' => 'https://docs.gravitykit.com/article/490-entry-approval-gravity-forms',
 					),
 				),
+				'search_visible_fields'       => [
+					'label' => __( 'Search in visible fields only', 'gk-gravityview' ),
+					'type'  => 'checkbox',
+					'group' => 'default',
+					'value' => 0,
+					'desc'  => __( 'Limit "Search Everything" search results to visible fields only.', 'gk-gravityview' ),
+				],
 				'caching'                     => array(
 					'label'             => __( 'Enable caching', 'gk-gravityview' ),
 					'type'              => 'checkbox',

--- a/includes/admin/metaboxes/views/view-settings.php
+++ b/includes/admin/metaboxes/views/view-settings.php
@@ -21,6 +21,8 @@ $current_settings = gravityview_get_template_settings( $post->ID );
 
 	GravityView_Render_Settings::render_setting_row( 'admin_show_all_statuses', $current_settings );
 
+	GravityView_Render_Settings::render_setting_row( 'search_visible_fields', $current_settings );
+
 	GravityView_Render_Settings::render_setting_row( 'caching', $current_settings );
 
 	GravityView_Render_Settings::render_setting_row( 'caching_entries', $current_settings );

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -12,6 +12,8 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+require_once __DIR__ . '/settings/class-search-widget-settings-visible-fields-only.php';
+
 class GravityView_Widget_Search extends \GV\Widget {
 
 	public $icon = 'dashicons-search';
@@ -983,7 +985,6 @@ class GravityView_Widget_Search extends \GV\Widget {
 				unset( $search_criteria['field_filters'][ $i ] );
 			}
 		}
-
 
 		$widgets = $view->widgets->by_id( $this->widget_id );
 		if ( $widgets->count() ) {

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -2,7 +2,6 @@
 /**
  * The GravityView New Search widget
  *
- * @package   GravityView-DataTables-Ext
  * @license   GPL2+
  * @author    GravityKit <hello@gravitykit.com>
  * @link      http://www.gravitykit.com
@@ -737,16 +736,16 @@ class GravityView_Widget_Search extends \GV\Widget {
 
 				// Certain form field meta values are stored as JSON, so we need to encode them before searching.
 				// This replicates the behavior of GF_Query_JSON_Literal::sql().
-				$value = $params['value'] ?? '';
+				$original_value = $params['value'] ?? '';
 
-				if ( $use_json_storage && $value && is_string( $value ) ) {
-					$value = trim( json_encode( $value ), '"' );
+				if ( $use_json_storage && $original_value && is_string( $original_value ) ) {
+					$value = trim( json_encode( $original_value ), '"' );
 					$value = str_replace( '\\', '\\\\', $value );
 
-					$search_criteria['field_filters'][] = array_merge(
-						$params,
-						[ 'value' => $value ]
-					);
+					if ( $value !== $original_value ) {
+						$params['value']                    = $value;
+						$search_criteria['field_filters'][] = $params;
+					}
 				}
 			}
 		}

--- a/includes/widgets/search-widget/settings/class-search-widget-settings-visible-fields-only.php
+++ b/includes/widgets/search-widget/settings/class-search-widget-settings-visible-fields-only.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * Setting that limits the search results of "Search Everything" to visible fields only.
+ *
+ * @since     $ver$
+ *
+ * @package   GravityView
+ * @license   GPL2+
+ * @link      http://www.gravitykit.com
+ */
+
+use GV\Field;
+use GV\Internal_Field;
+use GV\View;
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Manages the Query to limit Search Everything searches to visible fields only.
+ *
+ * @since $ver$
+ */
+final class GravityView_Search_Widget_Settings_Visible_Fields_Only {
+	/**
+	 * Holds the single instance.
+	 *
+	 * @since $ver$
+	 *
+	 * @var self
+	 */
+	private static self $instance;
+
+	/**
+	 * Whether the current query should be skipped.
+	 *
+	 * @since $ver$
+	 *
+	 * @var bool
+	 */
+	private static bool $should_skip = false;
+
+	/**
+	 * Returns the singleton.
+	 *
+	 * @since $ver%
+	 */
+	public static function get_instance(): self {
+		return self::$instance ??= new self();
+	}
+
+	/**
+	 * Prevent multiple instances.
+	 *
+	 * @since $ver$
+	 */
+	private function __construct() {
+		add_action( 'gravityview/view/query', [ $this, 'maybe_update_search_condition' ], 2048, 2 );
+	}
+
+	/**
+	 * Updates the search condition to limit the search to visible fields only.
+	 *
+	 * @since $ver$
+	 *
+	 * @param GF_Query $query The Query.
+	 * @param View     $view  The View.
+	 */
+	public function maybe_update_search_condition( GF_Query $query, View $view ): void {
+		// If the current user can search everything, we don't need to do anything.
+		$where = $query->_introspect()['where'] ?? null;
+
+		if ( ! $where || ! $this->is_search_limited( $view ) ) {
+			return;
+		}
+
+		$visible_fields = $this->get_visible_fields( $view );
+		$condition      = $this->replace_condition( $query, $where, $visible_fields );
+
+		$query->where( $condition );
+	}
+
+	/**
+	 * Returns if the search is limited to visible fields only.
+	 *
+	 * @since $ver$
+	 *
+	 * @param View $view The View.
+	 *
+	 * @return bool Whether the current user can search everything.
+	 */
+	private function is_search_limited( View $view ): bool {
+		if ( self::$should_skip ) {
+			return false;
+		}
+
+		$is_visible_fields_only = $view->settings->get( 'search_visible_fields', 0 );
+
+		/**
+		 * @filter `gk/gravityview/widget/search/visible_fields_only` Modify the search capability of "Search Everything".
+		 *
+		 * @since  $ver$
+		 *
+		 * @param bool $is_visible_fields_only Whether the search capability of "Search Everything" is limited to visible fields only.
+		 * @param View $view                   The View.
+		 */
+		return (bool) apply_filters(
+			'gk/gravityview/widget/search/visible_fields_only',
+			$is_visible_fields_only,
+			$view
+		);
+	}
+
+	/**
+	 * Returns if the condition is a condition group.
+	 *
+	 * @since $ver$
+	 *
+	 * @param GF_Query_Condition $condition The condition to check.
+	 *
+	 * @return bool Whether the condition is a condition group.
+	 */
+	private function is_condition_group( GF_Query_Condition $condition ): bool {
+		return in_array( $condition->operator, [ GF_Query_Condition::_AND, GF_Query_Condition::_OR ], true );
+	}
+
+	/**
+	 * Returns if the condition is an excluded field.
+	 *
+	 * @since $ver$
+	 *
+	 * @param GF_Query_Condition $condition The condition to check.
+	 * @param array              $fields    The visible fields.
+	 *
+	 * @return bool Whether the condition is an excluded field.
+	 */
+	private function is_excluded_field( GF_Query_Condition $condition, array $fields ): bool {
+		$left = $condition->left ?? null;
+		if (
+			! $left instanceof GF_Query_Column
+			|| GF_Query_Column::META === $left->field_id
+		) {
+			return false;
+		}
+
+		// Check for field ID or field wild card in visible fields.
+		$ids   = [ $left->field_id, $left->field_id . '.%' ];
+		$found = array_intersect( $ids, $fields[ $condition->left->source ] ?? [] );
+
+		// If neither is found, the field is excluded.
+		return [] === $found;
+	}
+
+	/**
+	 * Returns if the condition is a "Search Everything" condition.
+	 *
+	 * @since $ver$
+	 *
+	 * @param GF_Query_Condition $condition The condition to check.
+	 *
+	 * @return bool Whether the condition is a "Search Everything" condition.
+	 */
+	private function is_search_everything_condition( GF_Query_Condition $condition ): bool {
+		return $condition->left instanceof GF_Query_Column && GF_Query_Column::META === $condition->left->field_id;
+	}
+
+	/**
+	 * Returns if the condition's field ID is in the visible fields.
+	 *
+	 * @since $ver$
+	 *
+	 * @param GF_Query_Condition $condition The condition to check.
+	 * @param array              $fields    The visible fields.
+	 *
+	 * @return bool Whether the condition's field ID is in the visible fields.
+	 */
+	private function is_in_configured_forms( GF_Query_Condition $condition, array $fields ): bool {
+		return $condition->left instanceof GF_Query_Column && array_key_exists( $condition->left->source, $fields );
+	}
+
+	/**
+	 * Recursively replaces the entire query conditions tree.
+	 *
+	 * @since $ver$
+	 *
+	 * @param GF_Query                      $query     The Query.
+	 * @param GF_Query_Condition            $condition The condition to update.
+	 * @param array<int, array<int|string>> $fields    The field configuration.
+	 *
+	 * @return GF_Query_Condition
+	 */
+	private function replace_condition(
+		GF_Query $query,
+		GF_Query_Condition $condition,
+		array $fields
+	): ?GF_Query_Condition {
+		// Traverse down the condition tree when it is a group.
+		if ( $this->is_condition_group( $condition ) ) {
+			$expressions = array_map(
+				fn( GF_Query_Condition $expression ) => $this->replace_condition( $query, $expression, $fields ),
+				$condition->expressions ?? []
+			);
+
+			// No need to nest a single condition in a group.
+			if ( count( $expressions ) === 1 ) {
+				return reset( $expressions );
+			}
+
+			return GF_Query_Condition::_AND === $condition->operator
+				? GF_Query_Condition::_and( ...$expressions )
+				: GF_Query_Condition::_or( ...$expressions );
+		}
+
+		// If the form is not configured explicitly, include regular condition.
+		if ( ! $this->is_in_configured_forms( $condition, $fields ) ) {
+			return $condition;
+		}
+
+		// Remove excluded fields from the condition.
+		if ( $this->is_excluded_field( $condition, $fields ) ) {
+			return null;
+		}
+
+		// If the condition is not a "Search Everything" condition, we don't need to do anything.
+		if ( ! $this->is_search_everything_condition( $condition ) ) {
+			return $condition;
+		}
+
+		$source = $condition->left->source;
+		// If an array is set, but it is empty; it should exclude aLL values; so we replace it with an invalid statement.
+		if ( ! $fields[ $source ] ) {
+			return null;
+		}
+
+		$exact = [];
+		$like  = [];
+
+		foreach ( $fields[ $source ] as $field_id ) {
+			if ( strpos( $field_id, '%' ) !== false ) {
+				$like[] = $field_id;
+			} else {
+				$exact[] = $field_id;
+			}
+		}
+
+		$meta_key_column = new GF_Query_Column(
+			'meta_key',
+			$condition->left->source,
+			$query->_alias( GF_Query_Column::META, $source, 'm' )
+		);
+
+		$new_conditions = [];
+
+		if ( $exact ) {
+			$new_conditions[] = new GF_Query_Condition(
+				$meta_key_column,
+				GF_Query_Condition::IN,
+				new GF_Query_Series(
+					array_map(
+						static fn( $field_id ) => new GF_Query_Literal( $field_id ),
+						$exact
+					)
+				)
+			);
+		}
+
+		if ( $like ) {
+			foreach ( $like as $field_id ) {
+				$new_conditions[] = new GF_Query_Condition(
+					$meta_key_column,
+					GF_Query_Condition::LIKE,
+					new GF_Query_Literal( $field_id )
+				);
+			}
+		}
+
+		if ( $new_conditions ) {
+			$strict_condition = count( $new_conditions ) === 1
+				? reset( $new_conditions )
+				: GF_Query_Condition::_or( ...$new_conditions );
+		}
+
+		return GF_Query_Condition::_and( $condition, $strict_condition ?? null );
+	}
+
+	/**
+	 * Returns the visible fields per form on the View.
+	 *
+	 * @since $ver$
+	 *
+	 * @param View $view The View.
+	 *
+	 * @return array<int, array<int|string>> The visible fields per form on the View.
+	 */
+	private function get_visible_fields( View $view ): array {
+		self::$should_skip = true; // Prevent infinite loop.
+
+		$fields = array_reduce(
+			$view->fields->by_visible( $view )->all(),
+			static function ( array $fields, Field $field ) {
+				if ( $field instanceof Internal_Field && 'meta' === $field->field->group ) {
+					return $fields;
+				}
+
+				$configuration = $field->as_configuration();
+
+				$field_id = $configuration['id'];
+				if (
+					false === strpos( $field_id, '.' )
+					&& $field->field instanceof GF_Field
+					&& $field->field->get_entry_inputs()
+				) {
+					$field_id .= '.%';
+				}
+				$fields[ $configuration['form_id'] ?? 0 ][] = $field_id;
+
+				return $fields;
+			},
+			[]
+		);
+
+		$form_ids   = array_column( View::get_joined_forms( $view->ID ), 'ID' );
+		$form_ids[] = gravityview_get_form_id( $view->ID );
+
+		// Make sure all joined forms are in the array.
+		foreach ( $form_ids as $form_id ) {
+			$fields[ $form_id ] = array_values( array_unique( $fields[ $form_id ] ?? [] ) );
+		}
+
+		self::$should_skip = false;
+
+		return $fields;
+	}
+}
+
+GravityView_Search_Widget_Settings_Visible_Fields_Only::get_instance();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="GravityView">
     <!-- General -->
-    <config name="testVersion" value="7.2-"/>
+    <config name="testVersion" value="7.4-"/>
 
     <arg name="colors"/>
     <arg value="sp"/>


### PR DESCRIPTION
This PR introduces a new feature that allows users to limit "Search Everything" functionality to only visible fields in a GravityView, enhancing security and providing more granular control over search capabilities.

### New View Setting
- **Added setting`search_visible_fields`** - A new checkbox setting in View configuration that allows administrators to restrict "Search Everything" searches to only fields that are currently visible in the View
- Default value is `0` (disabled) to maintain backward compatibility
- Setting includes descriptive help text: "Limit 'Search Everything' search results to visible fields only"

### Key Features
1. **Security Enhancement** - Prevents users from searching against hidden/sensitive fields through the "Search Everything" widget
2. **Granular Control** - Administrators can now control exactly which fields are searchable via the global search
3. **Backward Compatibility** - Feature is disabled by default, ensuring existing Views continue to work as expected
4. **Filter Support** - Includes filter for programmatic control `gk/gravityview/widget/search/visible_fields_only`
