### PR TITLE
Release 2.42.1

### DIFF
--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.42
+ * Version:             2.42.1
  * Requires PHP:        7.4.0
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
@@ -32,7 +32,7 @@ if ( ! GravityKit\GravityView\Foundation\meets_min_php_version_requirement( __FI
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.42' );
+define( 'GV_PLUGIN_VERSION', '2.42.1' );
 
 /**
  * Full path to the GravityView file

--- a/includes/search/fields/class-search-field-gravity-forms.php
+++ b/includes/search/fields/class-search-field-gravity-forms.php
@@ -7,6 +7,7 @@ use GF_Query_Column;
 use GFAPI;
 use GFCommon;
 use GFFormsModel;
+use GravityView_Fields;
 use GravityView_Widget_Search;
 
 /**
@@ -182,12 +183,20 @@ final class Search_Field_Gravity_Forms extends Search_Field_Choices {
 	private function get_field_icon(): string {
 		// Use Gravity Forms' field icon if available.
 		$field = $this->get_gf_field();
+
 		if ( $field ) {
-			return $field->get_form_editor_field_type_icon();
+			// GF 2.9+.
+			if ( method_exists( $field, 'get_form_editor_field_type_icon' ) ) {
+				return $field->get_form_editor_field_type_icon();
+			} elseif ( method_exists( $field, 'get_form_editor_field_icon' ) ) {
+				// GF 2.5+.
+				return $field->get_form_editor_field_icon();
+			}
 		}
 
 		// Use GravityView's field icon next, if available.
-		$field = \GravityView_Fields::get( $this->get_field_id() );
+		$field = GravityView_Fields::get( $this->get_field_id() );
+
 		if ( $field ) {
 			return $field->get_icon();
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === GravityView ===
 Tags: gravity forms, directory, gravity forms directory
 Requires at least: 4.7
-Tested up to: 6.8.1
+Tested up to: 6.8.2
 Requires PHP: 7.4.0
 Stable tag: trunk
 Contributors: The GravityKit Team
@@ -20,6 +20,13 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 3. Follow the instructions
 
 == Changelog ==
+
+= 2.42.1 on July 16, 2025 =
+
+This patch resolves a fatal error that could occur when using the plugin with older versions of Gravity Forms.
+
+#### 🐛 Fixed
+* Fatal error due to a call to an undefined method when using GravityView with Gravity Forms versions older than 2.9.
 
 = 2.42 on July 10, 2025 =
 


### PR DESCRIPTION
This patch resolves a fatal error that could occur when using the plugin with older versions of Gravity Forms.

#### 🐛 Fixed
* Fatal error due to a call to an undefined method when using GravityView with Gravity Forms versions older than 2.9.
