### PR TITLE
Release 2.42.2

### DIFF
--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.42.1
+ * Version:             2.42.2
  * Requires PHP:        7.4.0
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
@@ -32,7 +32,7 @@ if ( ! GravityKit\GravityView\Foundation\meets_min_php_version_requirement( __FI
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.42.1' );
+define( 'GV_PLUGIN_VERSION', '2.42.2' );
 
 /**
  * Full path to the GravityView file

--- a/includes/fields/class-gravityview-field-address.php
+++ b/includes/fields/class-gravityview-field-address.php
@@ -61,9 +61,9 @@ class GravityView_Field_Address extends GravityView_Field {
 	 * Dynamically add choices to the address field dropdowns, if any
 	 *
 	 * @since 1.19.2
-	 * @since TBD Removed the unused `$widget` and `$widget_args` parameters.
+	 * @since 2.42.2 Removed `$widget` and `$widget_args` parameters.
 	 *
-	 * @param array                     $search_fields Array of search filters with `key`, `label`, `value`, `type` keys
+	 * @param array $search_fields Array of search filters with `key`, `label`, `value`, `type` keys
 	 *
 	 * @return array If the search field GF Field type is `address`, and there are choices to add, adds them and changes the input type. Otherwise, sets the input to text.
 	 */

--- a/includes/fields/class-gravityview-field-address.php
+++ b/includes/fields/class-gravityview-field-address.php
@@ -5,6 +5,8 @@
  * @subpackage includes\fields
  */
 
+use GV\Utils;
+
 /**
  * Add custom options for address fields
  */
@@ -59,18 +61,16 @@ class GravityView_Field_Address extends GravityView_Field {
 	 * Dynamically add choices to the address field dropdowns, if any
 	 *
 	 * @since 1.19.2
+	 * @since TBD Removed the unused `$widget` and `$widget_args` parameters.
 	 *
 	 * @param array                     $search_fields Array of search filters with `key`, `label`, `value`, `type` keys
-	 * @param GravityView_Widget_Search $widget Current widget object
-	 * @param array                     $widget_args Args passed to this method. {@since 1.8}
 	 *
 	 * @return array If the search field GF Field type is `address`, and there are choices to add, adds them and changes the input type. Otherwise, sets the input to text.
 	 */
-	public function search_field_filter( $search_fields, $widget, $widget_args ) {
+	public function search_field_filter( $search_fields ) {
+		foreach ( $search_fields as &$search_field ) {
 
-		foreach ( $search_fields as & $search_field ) {
-
-			if ( 'address' !== \GV\Utils::get( $search_field, 'type' ) ) {
+			if ( 'address' !== Utils::get( $search_field, 'gf_field_type' ) ) {
 				continue;
 			}
 
@@ -94,7 +94,7 @@ class GravityView_Field_Address extends GravityView_Field {
 
 			if ( ! empty( $choices ) ) {
 				$search_field['choices'] = $choices;
-				$search_field['type']    = \GV\Utils::get( $search_field, 'input' );
+				$search_field['type']    = Utils::get( $search_field, 'input' );
 			} else {
 				$search_field['type']  = 'text';
 				$search_field['input'] = 'input_text';
@@ -203,7 +203,7 @@ class GravityView_Field_Address extends GravityView_Field {
 	public function input_types( $input_types ) {
 
 		// Use the same inputs as the "text" input type allows
-		$text_inputs = \GV\Utils::get( $input_types, 'text' );
+		$text_inputs = Utils::get( $input_types, 'text' );
 
 		$input_types['street']  = $text_inputs;
 		$input_types['street2'] = $text_inputs;

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-image-hopper.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-image-hopper.php
@@ -88,7 +88,7 @@ final class GravityView_Plugin_Hooks_Image_Hopper extends GravityView_Plugin_and
 	 * @return bool Whether the field is an Image Hopper field.
 	 */
 	private static function is_image_hopper_field( GF_Field $field ): bool {
-		return 'image_hopper' === $field->type;
+		return 'image_hopper' === $field->type || 'image_hopper_post' === $field->type;
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9173,17 +9173,18 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.5",
-        "bytes": "3.0.0",
-        "compressible": "~2.0.16",
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
         "debug": "2.6.9",
-        "on-headers": "~1.0.2",
-        "safe-buffer": "5.1.2",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
       "engines": {
@@ -9191,10 +9192,11 @@
       }
     },
     "node_modules/compression/node_modules/bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9214,11 +9216,15 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/compression/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -21210,10 +21216,11 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/readme.txt
+++ b/readme.txt
@@ -23,10 +23,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = 2.42.2 on July 17, 2025 =
 
-This hotfix resolves an issue where Address field subfields were not appearing in the Search Bar widget on the frontend.
+This hotfix resolves a display issue introduced in 2.42 affecting address subfields in the Search Bar widget, and fixes a fatal error related to the Image Hopper Post Image field.
 
 #### 🐛 Fixed
-* Address field subfields (State/Province, City, etc.) were not displaying in the Search Bar widget.
+* Address field subfields (State/Province, City, etc.) were not displaying in the Search Bar widget after the 2.42 update.
+* Fatal error when editing an entry containing an Image Hopper Post Image field.
 
 = 2.42.1 on July 16, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+#### 🐛 Fixed
+* Address field subfields (State/Province, City, etc.) were not displaying in the Search Bar widget.
+
 = 2.42.1 on July 16, 2025 =
 
 This patch resolves a fatal error that could occur when using the plugin with older versions of Gravity Forms.

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
-= develop =
+= 2.42.2 on July 17, 2025 =
+
+This hotfix resolves an issue where Address field subfields were not appearing in the Search Bar widget on the frontend.
 
 #### 🐛 Fixed
 * Address field subfields (State/Province, City, etc.) were not displaying in the Search Bar widget.


### PR DESCRIPTION
This hotfix resolves a display issue introduced in 2.42 affecting address subfields in the Search Bar widget, and fixes a fatal error related to the Image Hopper Post Image field.

#### 🐛 Fixed
* Address field subfields (State/Province, City, etc.) were not displaying in the Search Bar widget after the 2.42 update.
* Fatal error when editing an entry containing an Image Hopper Post Image field.
