### PR TITLE
Fix flaky edit entry test

### DIFF
--- a/tests/E2E/tests/edit-entry/file-size-limit.spec.js
+++ b/tests/E2E/tests/edit-entry/file-size-limit.spec.js
@@ -31,7 +31,7 @@ test('File size limit validation during entry edit', async ({ page }) => {
   const validImagePath = path.join(__dirname, '../../helpers/gf-importer/data/images/fog.jpg');
   await fileInput.setInputFiles(validImagePath);
 
-  await expect(page.getByText(/fog\.jpg/i)).toBeVisible();
+  await expect(page.getByText('fog.jpg', { exact: true })).toBeVisible();
 
   await page.getByLabel('Name(Required)').fill('');
 

--- a/tests/E2E/tests/edit-entry/max-file-deletion-rollback.spec.js
+++ b/tests/E2E/tests/edit-entry/max-file-deletion-rollback.spec.js
@@ -51,8 +51,8 @@ test('Does not restore deleted files after validation failure', async ({ page })
   const fileInput = page.locator('input[type="file"]:visible');
   await fileInput.setInputFiles([fogImagePath, blizzardImagePath]);
 
-  await expect(page.getByText(/fog\.jpg/i)).toBeVisible();
-  await expect(page.getByText(/blizzard\.jpg/i)).toBeVisible();
+  await expect(page.getByText('fog.jpg', { exact: true })).toBeVisible();
+  await expect(page.getByText('blizzard.jpg', { exact: true })).toBeVisible();
 
   const updateButton = page.getByRole('button', { name: 'Update' });
   while (uploadInProgress) {


### PR DESCRIPTION
Used a more specific selector to prevent test flakiness. Also, implemented the more specific selector in another test.