### PR TITLE
Release 2.43.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,4 +165,3 @@ workflows:
           requires:
             - run_php_74_unit_tests
             - run_php_80_unit_tests
-            - run_e2e_tests

--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.43
+ * Version:             2.43.1
  * Requires PHP:        7.4.0
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
@@ -32,7 +32,7 @@ if ( ! GravityKit\GravityView\Foundation\meets_min_php_version_requirement( __FI
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.43' );
+define( 'GV_PLUGIN_VERSION', '2.43.1' );
 
 /**
  * Full path to the GravityView file

--- a/includes/admin/class.field.type.php
+++ b/includes/admin/class.field.type.php
@@ -40,7 +40,27 @@ abstract class GravityView_FieldType {
 
 		$this->field = wp_parse_args( $field, $defaults );
 
-		$this->value = is_null( $curr_value ) || '' === $curr_value ? $this->field['value'] : $curr_value;
+		// Preserve empty string if it's a valid option for radio/select fields.
+		// Otherwise, empty string or null means "use default".
+		$is_empty_valid_option = (
+			in_array( $this->field['type'], [ 'radio', 'select' ], true )
+			&& ! empty( $this->field['options'] )
+			&& array_key_exists( '', $this->field['options'] )
+		);
+
+		if ( null === $curr_value ) {
+			$this->value = $this->field['value'];
+
+			return;
+		}
+
+		if ( '' === $curr_value && ! $is_empty_valid_option ) {
+			$this->value = $this->field['value'];
+
+			return;
+		}
+
+		$this->value = $curr_value;
 	}
 
 	/**

--- a/includes/class-admin-views.php
+++ b/includes/class-admin-views.php
@@ -264,17 +264,20 @@ class GravityView_Admin_Views {
 		$current_form = \GV\Utils::_GET( 'gravityview_form_id' );
 
 		// If there are no forms to select, show no forms.
-		if ( ! empty( $forms ) ) { ?>
+		if ( ! empty( $forms ) && is_array( $forms ) ) { ?>
             <label for="gravityview_form_id" class="screen-reader-text"><?php esc_html_e( 'Filter Views by form',
 					'gk-gravityview' ); ?></label>
             <select name="gravityview_form_id" id="gravityview_form_id">
                 <option value="" <?php selected( '', $current_form, true ); ?>><?php esc_html_e( 'All forms',
 						'gk-gravityview' ); ?></option>
-				<?php foreach ( $forms as $form ) { ?>
-                    <option value="<?php echo esc_attr( $form['id'] ); ?>" <?php selected( $form['id'],
-						$current_form,
-						true ); ?>><?php echo esc_html( $form['title'] ); ?></option>
-				<?php } ?>
+							<?php foreach ( $forms as $form ) {
+									if ( ! is_array( $form ) || ! isset( $form['id'], $form['title'] ) ) {
+										continue;
+									} ?>
+									<option value="<?php echo esc_attr( $form['id'] ); ?>" <?php selected( $form['id'], $current_form, true ); ?>>
+											<?php echo esc_html( $form['title'] ); ?>
+									</option>
+							<?php } ?>
             </select>
 			<?php
 		}

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -430,7 +430,7 @@ class GVCommon {
 		// Handle case-insensitive title sorting with uppercase/lowercase letters
 		if ( ! empty( $forms ) && 'title' === $order_by ) {
 			uasort( $forms, function( $a, $b ) use ( $order ) {
-				$result = strnatcasecmp( $a['title'], $b['title'] );
+				$result = strnatcasecmp( $a['title'] ?? '', $b['title'] ?? '' );
 				return ( 'DESC' === $order ) ? -$result : $result;
 			});
 		} elseif ( ! empty( $forms ) ) {

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-signature.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-signature.php
@@ -80,7 +80,17 @@ class GravityView_Plugin_Hooks_Gravity_Forms_Signature extends GravityView_Plugi
 
 		// We need to fetch a fresh version of the entry, since the saved entry hasn't refreshed in GV yet.
 		$entry       = GravityView_View::getInstance()->getCurrentEntry();
-		$entry       = GFAPI::get_entry( $entry['id'] );
+
+		// Ensure the entry has an ID before attempting to refresh it
+		if ( ! is_array( $entry ) || empty( $entry['id'] ) ) {
+			return $field_content;
+		}
+
+		$entry = GFAPI::get_entry( $entry['id'] );
+		if ( is_wp_error( $entry ) ) {
+			return $field_content;
+		}
+
 		$entry_value = \GV\Utils::get( $entry, $field->id );
 
 		$_POST[ "input_{$field->id}" ]                               = $entry_value; // Used when Edit Entry form *is* submitted

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-signature.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-signature.php
@@ -12,6 +12,8 @@
  * @since 1.17
  */
 
+use GV\Utils;
+
 /**
  * @inheritDoc
  * @since 1.17
@@ -79,9 +81,19 @@ class GravityView_Plugin_Hooks_Gravity_Forms_Signature extends GravityView_Plugi
 		}
 
 		// We need to fetch a fresh version of the entry, since the saved entry hasn't refreshed in GV yet.
-		$entry       = GravityView_View::getInstance()->getCurrentEntry();
-		$entry       = GFAPI::get_entry( $entry['id'] );
-		$entry_value = \GV\Utils::get( $entry, $field->id );
+		$entry = GravityView_View::getInstance()->getCurrentEntry();
+
+		if ( ! is_array( $entry ) || empty( $entry['id'] ) ) {
+			return $field_content;
+		}
+
+		$entry = GFAPI::get_entry( $entry['id'] );
+
+		if ( is_wp_error( $entry ) ) {
+			return $field_content;
+		}
+
+		$entry_value = Utils::get( $entry, $field->id );
 
 		$_POST[ "input_{$field->id}" ]                               = $entry_value; // Used when Edit Entry form *is* submitted
 		$_POST[ "input_{$form_id}_{$field->id}_signature_filename" ] = $entry_value; // Used when Edit Entry form *is not* submitted

--- a/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-signature.php
+++ b/includes/plugin-and-theme-hooks/class-gravityview-plugin-hooks-gravity-forms-signature.php
@@ -80,17 +80,7 @@ class GravityView_Plugin_Hooks_Gravity_Forms_Signature extends GravityView_Plugi
 
 		// We need to fetch a fresh version of the entry, since the saved entry hasn't refreshed in GV yet.
 		$entry       = GravityView_View::getInstance()->getCurrentEntry();
-
-		// Ensure the entry has an ID before attempting to refresh it
-		if ( ! is_array( $entry ) || empty( $entry['id'] ) ) {
-			return $field_content;
-		}
-
-		$entry = GFAPI::get_entry( $entry['id'] );
-		if ( is_wp_error( $entry ) ) {
-			return $field_content;
-		}
-
+		$entry       = GFAPI::get_entry( $entry['id'] );
 		$entry_value = \GV\Utils::get( $entry, $field->id );
 
 		$_POST[ "input_{$field->id}" ]                               = $entry_value; // Used when Edit Entry form *is* submitted

--- a/readme.txt
+++ b/readme.txt
@@ -23,14 +23,14 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = 2.43.1 on July 31, 2025 =
 
-This update fixes several issues including DIY Layout container tag selection, time field display, and resolves PHP warnings and deprecation messages.
+This update fixes several issues, including DIY Layout container tag selection, incorrect Time field value display, and various PHP warnings and deprecation messages.
 
 #### 🐛 Fixed
-* Time fields displaying incorrect times when the server and WordPress were set to different timezones.
-* Selecting "none" as the View field container tag in DIY Layout would reset to "div" after saving.
-* Inline editing being automatically enabled on Single Entry pages in List Views when using GravityEdit.
+* Time field values displaying incorrectly when the server and WordPress are set to different timezones.
+* Choosing "None" as the container tag in DIY Layout not being saved and reverting to "DIV".
+* Inline editing automatically enabled on Single Entry pages in List Views when using GravityEdit.
 * "Undefined array key" PHP warning that could occur when using the Gravity Forms Signature Add-On.
-* General PHP warnings and deprecated notices.
+* Various PHP warnings and deprecated notices.
 
 = 2.43 on July 24, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 #### 🐛 Fixed
 * "Undefined array key" PHP warning that could occur when using the Gravity Forms Signature Add-On.
+* Time fields showing the wrong time when the server and WordPress are in different timezones.
 
 = 2.43 on July 24, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,12 +21,16 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
-= develop =
+= 2.43.1 on July 31, 2025 =
+
+This update fixes several issues including DIY Layout container tag selection, time field display, and resolves PHP warnings and deprecation messages.
 
 #### 🐛 Fixed
+* Time fields displaying incorrect times when the server and WordPress were set to different timezones.
+* Selecting "none" as the View field container tag in DIY Layout would reset to "div" after saving.
+* Inline editing being automatically enabled on Single Entry pages in List Views when using GravityEdit.
 * "Undefined array key" PHP warning that could occur when using the Gravity Forms Signature Add-On.
-* Time fields showing the wrong time when the server and WordPress are in different timezones.
-* Selecting "none" as the View field's container tag in DIY Layout would reset to "div".
+* General PHP warnings and deprecated notices.
 
 = 2.43 on July 24, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+#### 🐛 Fixed
+* "Undefined array key" PHP warning that could occur when using the Gravity Forms Signature Add-On.
+
 = 2.43 on July 24, 2025 =
 
 This update adds support for displaying Views inside Jetpack CRM Client Portal Pro pages, fixes entry sorting on the Gravity Forms Entries page when filtering by approval status, and resolves Search Bar issues involving the Chained Selects Add-On and Approval Status search.

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 #### 🐛 Fixed
 * "Undefined array key" PHP warning that could occur when using the Gravity Forms Signature Add-On.
 * Time fields showing the wrong time when the server and WordPress are in different timezones.
+* Selecting "none" as the View field's container tag in DIY Layout would reset to "div".
 
 = 2.43 on July 24, 2025 =
 

--- a/templates/entries/list.php
+++ b/templates/entries/list.php
@@ -32,6 +32,8 @@ gravityview_before( $gravityview );
 	<?php if ( $has_title || $has_subtitle || $has_image || $has_description || $has_content_attributes || $has_footer_left || $has_footer_right ) : ?>
 		<div id="gv_list_<?php echo esc_attr( $entry_slug ); ?>" class="gv-list-view">
 
+		<?php gravityview_header( $gravityview ); ?>
+
 		<?php if ( $has_title || $has_subtitle ) { ?>
 
 			<div class="gv-list-view-title">

--- a/templates/fields/field-time-html.php
+++ b/templates/fields/field-time-html.php
@@ -2,12 +2,13 @@
 /**
  * The default time field output template.
  *
- * @global \GV\Template_Context $gravityview
  * @since 2.0
+ * @global \GV\Template_Context $gravityview
  */
 
 if ( ! isset( $gravityview ) || empty( $gravityview->template ) ) {
-	gravityview()->log->error( '{file} template loaded without context', array( 'file' => __FILE__ ) );
+	gravityview()->log->error( '{file} template loaded without context', [ 'file' => __FILE__ ] );
+
 	return;
 }
 
@@ -23,18 +24,20 @@ if ( false !== strpos( $value, '00:00' ) ) {
 $output = '';
 
 if ( '' !== $value ) {
+	$view_field_format = $gravityview->field->date_display;
 
-	$format = $gravityview->field->date_display;
-
-	if ( empty( $format ) ) {
-
+	if ( empty( $view_field_format ) ) {
 		$field->sanitize_settings();
 
-		$format = GravityView_Field_Time::date_format( $field->timeFormat, $field_id );
+		$view_field_format = GravityView_Field_Time::date_format( $field->timeFormat, $field_id );
 	}
 
-	// If there is a custom PHP date format passed via the date_display setting, use PHP's date format
-	$output = date_i18n( $format, strtotime( $value ) );
+	$form_field_format = ( '12' === $field->timeFormat ) ? 'h:i A' : 'H:i';
+
+	$datetime  = DateTime::createFromFormat( $form_field_format, $value, new DateTimeZone( 'UTC' ) );
+	$timestamp = $datetime ? $datetime->getTimestamp() : strtotime( $value );
+
+	$output = date_i18n( $view_field_format, $timestamp );
 }
 
 echo $output;

--- a/tests/E2E/tests/edit-entry/file-size-limit.spec.js
+++ b/tests/E2E/tests/edit-entry/file-size-limit.spec.js
@@ -31,7 +31,7 @@ test('File size limit validation during entry edit', async ({ page }) => {
   const validImagePath = path.join(__dirname, '../../helpers/gf-importer/data/images/fog.jpg');
   await fileInput.setInputFiles(validImagePath);
 
-  await expect(page.getByText(/fog\.jpg/i)).toBeVisible();
+  await expect(page.getByText('fog.jpg', { exact: true })).toBeVisible();
 
   await page.getByLabel('Name(Required)').fill('');
 

--- a/tests/E2E/tests/edit-entry/max-file-deletion-rollback.spec.js
+++ b/tests/E2E/tests/edit-entry/max-file-deletion-rollback.spec.js
@@ -51,8 +51,8 @@ test('Does not restore deleted files after validation failure', async ({ page })
   const fileInput = page.locator('input[type="file"]:visible');
   await fileInput.setInputFiles([fogImagePath, blizzardImagePath]);
 
-  await expect(page.getByText(/fog\.jpg/i)).toBeVisible();
-  await expect(page.getByText(/blizzard\.jpg/i)).toBeVisible();
+  await expect(page.getByText('fog.jpg', { exact: true })).toBeVisible();
+  await expect(page.getByText('blizzard.jpg', { exact: true })).toBeVisible();
 
   const updateButton = page.getByRole('button', { name: 'Update' });
   while (uploadInProgress) {


### PR DESCRIPTION
This update fixes several issues, including DIY Layout container tag selection, incorrect Time field value display, and various PHP warnings and deprecation messages.

#### 🐛 Fixed
* Time field values displaying incorrectly when the server and WordPress are set to different timezones.
* Choosing "None" as the container tag in DIY Layout not being saved and reverting to "DIV".
* Inline editing automatically enabled on Single Entry pages in List Views when using GravityEdit.
* "Undefined array key" PHP warning that could occur when using the Gravity Forms Signature Add-On.
* Various PHP warnings and deprecated notices.

💾 [Build file](https://www.dropbox.com/scl/fi/84o7421ldu712gmibd42s/gravityview-2.43.1-3f244836f.zip?rlkey=jijbuusa8gyiumim68frymvwa&dl=1) (3f244836f).