### PR TITLE
Fix search bar label visibility

### DIFF
--- a/includes/admin/class.render.settings.php
+++ b/includes/admin/class.render.settings.php
@@ -188,7 +188,7 @@ class GravityView_Render_Settings {
 				'show_label'        => [
 					'type'         => 'checkbox',
 					'label'        => __( 'Show Label', 'gk-gravityview' ),
-					'value'        => ! empty( $is_table_layout ),
+					'value'        => 'search' === $field_type ? true : ! empty( $is_table_layout ),
 					'priority'     => 1000,
 					'group'        => 'label',
 					'requires_not' => 'full_width=1',

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,12 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+#### 🐛 Fixed
+
+* New Search Bar field labels are now visible by default on any layout.
+
 = 2.43.2 on August 5, 2025 =
 
 This release introduces a flexible display format for checkbox fields, tightens Edit Entry security, and polishes File Upload presentation.


### PR DESCRIPTION
This PR addresses #2410, where on non-table layouts the label would be invisible on search fields. This is due to the logic for table layouts not showing the label by default. By excluding "search" field types, this is prevented. 