### PR TITLE
Fix PHP warning when using Date Range filter with single date

### DIFF
--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -833,7 +833,7 @@ class GravityView_Widget_Search extends \GV\Widget {
 				gv_empty( $value, false, false )
 				|| (
 					is_array( $value ) && 1 === count( $value )
-					&& gv_empty( $value[0], false, false )
+					&& gv_empty( reset( $value ), false, false )
 				)
 			) {
 				/**

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,12 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+#### 🐛 Fixed
+
+* Date Range filters now work correctly when only a start or end date is entered. Also fixes the issue when using the DataTables layout.
+
 = 2.43.2 on August 5, 2025 =
 
 This release introduces a flexible display format for checkbox fields, tightens Edit Entry security, and polishes File Upload presentation.


### PR DESCRIPTION
When entering only a start or end date in a Date Range filter, the search widget attempted to access array element [0] on an associative array, causing: "PHP Warning: Undefined array key 0 in class-search-widget.php on line 829"

Changed array access from $value[0] to reset($value) to properly handle both numeric and associative arrays.

Fixes issue where Date Range filters were ignored when only one date was entered in DataTables layout Views.

Resolves https://github.com/GravityKit/DataTables/issues/268