### PR TITLE
Always return expected response format from REST API, even when a View has no entries

### DIFF
--- a/future/includes/rest/class-gv-rest-views-route.php
+++ b/future/includes/rest/class-gv-rest-views-route.php
@@ -323,10 +323,6 @@ class Views_Route extends Route {
 
 		$entries = $view->get_entries( new Request( $request ) );
 
-		if ( ! $entries->all() ) {
-			return new \WP_Error( 'gravityview-no-entries', __( 'No Entries found.', 'gk-gravityview' ) );
-		}
-
 		if ( in_array( $format, array( 'csv', 'tsv' ), true ) ) {
 
 			ob_start();


### PR DESCRIPTION
I don't understand any scenario where you would want to have an error state when there are no entries. It seems like looping through an entry set of zero and returning the correct headers is the expected state. So I think that this code was a bug to begin with.

I've looked throughout our codebases and we don't have any expectation of the `gravityview-no-entries` error code being returned. Also, I searched for the string "No Entries found." and found no instances of that as well.

This seems to be the only place in our code where this response is used. I believe it is safe to remove it.

The only hesistance I have with this fix is that it doesn't automatically generate CSV headers when there are no entries; [those header columns are generated during the loop](https://github.com/GravityKit/GravityView/blob/01ea32a93097ee308200efab4981c4fa25fca005/future/includes/rest/class-gv-rest-views-route.php#L350), so while this is an improvement, it's also not a 100% perfect solution.

Resolves #2445

Related to https://secure.helpscout.net/conversation/3049597524/66587?viewId=408730

@mrcasual  I accidentally worked on this branch from another branch, so I'm merging into that one so it's a discrete change.

💾 [Build file](https://www.dropbox.com/scl/fi/274hp4026pinbs2a3s3u4/gravityview-2.44-01ea32a93.zip?rlkey=oq3mwslwmga6pjd0a5t63f293&dl=1) (01ea32a93).