### PR TITLE
Add support for List field column modifiers

### DIFF
--- a/includes/fields/class-gravityview-field-list.php
+++ b/includes/fields/class-gravityview-field-list.php
@@ -12,7 +12,6 @@
  * @since 1.14
  */
 class GravityView_Field_List extends GravityView_Field {
-
 	var $name = 'list';
 
 	/**
@@ -238,34 +237,36 @@ class GravityView_Field_List extends GravityView_Field {
 	}
 
 	/**
-	 * Handle List field column modifiers (e.g., {List:10:2} where "2" is the column number)
+	 * Handles List field column modifiers (e.g., `{List:10:2}` where "2" is the column number).
 	 *
 	 * @since TBD
 	 *
-	 * @param string   $return The current merge tag value to be filtered.
+	 * @param string   $return    The current merge tag value to be filtered.
 	 * @param string   $raw_value The raw value submitted for this field. May be CSV or JSON-encoded.
-	 * @param string   $value The original merge tag value, passed from Gravity Forms
+	 * @param string   $value     The original merge tag value, passed from Gravity Forms
 	 * @param string   $merge_tag If the merge tag being executed is an individual field merge tag (i.e. {Name:3}), this variable will contain the field's ID. If not, this variable will contain the name of the merge tag (i.e. all_fields).
-	 * @param string   $modifier The string containing any modifiers for this merge tag. For example, "maxwords:10" would be the modifiers for the following merge tag: `{Text:2:maxwords:10}`.
-	 * @param GF_Field $field The current field.
+	 * @param string   $modifier  The string containing any modifiers for this merge tag. For example, "maxwords:10" would be the modifiers for the following merge tag: `{Text:2:maxwords:10}`.
+	 * @param GF_Field $field     The current field.
 	 *
 	 * @return string
 	 */
 	public function handle_list_column_modifier( $return, $raw_value, $value, $merge_tag, $modifier, $field ) {
-		
-		// Only process for List fields with columns enabled
+		// Only process for List fields with columns enabled.
 		if ( ! $field instanceof GF_Field_List || ! $field->enableColumns ) {
 			return $return;
 		}
 
-		// Check if the modifier is a numeric column specifier
-		if ( is_numeric( $modifier ) ) {
-			$column_id = intval( $modifier );
-			$column_value = self::column_value( $field, $raw_value, $column_id, 'text' );
-			
-			if ( null !== $column_value ) {
-				return $column_value;
-			}
+		[ $column, $format ] = array_pad( explode( ':', $modifier, 2 ), 2, null );
+
+		if ( ! is_numeric( $column ) ) {
+			return $return;
+		}
+
+		$column_id    = (int) $modifier;
+		$column_value = self::column_value( $field, $raw_value, $column_id, $format ?: 'html' );
+
+		if ( null !== $column_value ) {
+			return $column_value;
 		}
 
 		return $return;

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
+#### 🚀 Added
+* Support for the List field merge tag modifier (e.g., `{List:1:2:text}`), enabling output of column values as an HTML list (default) or as a comma-separated string.
+
 #### 🐛 Fixed
 * Display issue with Checkbox field settings in the View editor where related "Link to single entry" options were not grouped together.
 


### PR DESCRIPTION
- Implements https://github.com/GravityKit/GravityView/issues/1694
- This update introduces a new filter to handle column modifiers for List fields, allowing for more flexible merge tag usage. The `handle_list_column_modifier` method processes numeric column specifiers, returning the appropriate column value when enabled. This enhancement improves the functionality of List fields in GravityView.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now use merge tag modifiers to output a specific column from List fields with columns enabled. Use a numeric modifier to target the desired column and display its values.
  * Improves flexibility when building notifications, confirmations, and content templates by allowing precise extraction of List field column data without affecting existing behavior for other field types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/caughxg8cfyo6hidrikcr/gravityview-2.45-82449d416.zip?rlkey=z6s6hiq2u8e4wds0lfmzjjisy&dl=1) (82449d416).