### PR TITLE
Release 2.46

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -40,3 +40,5 @@ translations.pot export-ignore
 /tests export-ignore
 /tests/* export-ignore
 /tests/unit-tests/* export-ignore
+.docusaurus/ export-ignore
+wp-hooks-docs/ export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,9 @@ wordpress-latest-tests-lib
 /tests/E2E/**/results/
 test-results/
 .claude/settings.local.json
+
+# Docusaurus
+.docusaurus/
+wp-hooks-docs/.docusaurus/
+wp-hooks-docs/build/
+wp-hooks-docs/node_modules/

--- a/composer.lock
+++ b/composer.lock
@@ -238,12 +238,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:GravityKit/Foundation.git",
-                "reference": "043eb14358e98ffd67a100ddee06629ec6e9d932"
+                "reference": "a19b9907f5d11aeda2217b323b36a8abd9a1c808"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GravityKit/Foundation/zipball/043eb14358e98ffd67a100ddee06629ec6e9d932",
-                "reference": "043eb14358e98ffd67a100ddee06629ec6e9d932",
+                "url": "https://api.github.com/repos/GravityKit/Foundation/zipball/a19b9907f5d11aeda2217b323b36a8abd9a1c808",
+                "reference": "a19b9907f5d11aeda2217b323b36a8abd9a1c808",
                 "shasum": ""
             },
             "require": {
@@ -341,10 +341,10 @@
                 }
             ],
             "support": {
-                "source": "https://github.com/GravityKit/Foundation/tree/v1.3.0",
+                "source": "https://github.com/GravityKit/Foundation/tree/v1.3.1",
                 "issues": "https://github.com/GravityKit/Foundation/issues"
             },
-            "time": "2025-08-28T20:46:44+00:00"
+            "time": "2025-09-04T17:12:24+00:00"
         },
         {
             "name": "illuminate/container",

--- a/future/includes/class-gv-collection-field.php
+++ b/future/includes/class-gv-collection-field.php
@@ -153,7 +153,9 @@ class Field_Collection extends Collection implements Collection_Position_Aware {
 	/**
 	 * Return a configuration array for this field collection.
 	 *
-	 * @return array See \GV\Field_Collection::from_configuration() for structure.
+	 * @see \GV\Field_Collection::from_configuration() for structure.
+	 *
+	 * @return array
 	 */
 	public function as_configuration() {
 		$configuration = array();

--- a/future/includes/class-gv-template-view-table.php
+++ b/future/includes/class-gv-template-view-table.php
@@ -264,8 +264,8 @@ class View_Table_Template extends View_Template {
 		/**
 		 * Modify the fields displayed in a table.
 		 *
-		 * @param array $fields
-		 * @param \GravityView_View $this
+		 * @param array $fields The fields. Refer to \GV\Field_Collection::from_configuration() for structure.
+		 * @param \GravityView_View $gravityview_view The GravityView_View object.
 		 * @deprecated Use `gravityview/template/table/fields`
 		 */
 		$fields = apply_filters( 'gravityview_table_cells', $fields->as_configuration(), \GravityView_View::getInstance() );
@@ -286,7 +286,7 @@ class View_Table_Template extends View_Template {
 		 * Filter the row attributes for the row in table view.
 		 *
 		 * @param array $attributes The HTML attributes.
-		 * @param \GV\Template_Context The context.
+		 * @param \GV\Template_Context $context The context.
 		 *
 		 * @since 2.0
 		 */
@@ -307,7 +307,7 @@ class View_Table_Template extends View_Template {
 				 *
 				 * @since 2.0
 				 *
-				 * @param \GV\Template_Context The context.
+				 * @param \GV\Template_Context $context The context.
 				 */
 				do_action( 'gravityview/template/table/cells/before', $context );
 
@@ -317,7 +317,7 @@ class View_Table_Template extends View_Template {
 				 * @deprecated Use `gravityview/template/table/cells/before`
 				 * @since 1.0.7
 				 *
-				 * @param \GravityView_View $this Current GravityView_View object
+				 * @param \GravityView_View $gravityview_view Current GravityView_View object
 				 */
 				do_action( 'gravityview_table_cells_before', \GravityView_View::getInstance() );
 
@@ -337,7 +337,7 @@ class View_Table_Template extends View_Template {
 				 *
 				 * @since 2.0
 				 *
-				 * @param \GV\Template_Context The context.
+				 * @param \GV\Template_Context $context The context.
 				 */
 				do_action( 'gravityview/template/table/cells/after', $context );
 
@@ -347,7 +347,7 @@ class View_Table_Template extends View_Template {
 				 * @deprecated Use `gravityview/template/table/cells/after`
 				 * @since 1.0.7
 				 *
-				 * @param \GravityView_View $this Current GravityView_View object
+				 * @param \GravityView_View $gravityview_view Current GravityView_View object
 				 */
 				do_action( 'gravityview_table_cells_after', \GravityView_View::getInstance() );
 

--- a/gravityview.php
+++ b/gravityview.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView
  * Plugin URI:          https://www.gravitykit.com
  * Description:         The best, easiest way to display Gravity Forms entries on your website.
- * Version:             2.45
+ * Version:             2.46
  * Requires PHP:        7.4.0
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
@@ -32,7 +32,7 @@ if ( ! GravityKit\GravityView\Foundation\meets_min_php_version_requirement( __FI
 /**
  * The plugin version.
  */
-define( 'GV_PLUGIN_VERSION', '2.45' );
+define( 'GV_PLUGIN_VERSION', '2.46' );
 
 /**
  * Full path to the GravityView file

--- a/includes/admin/class.render.settings.php
+++ b/includes/admin/class.render.settings.php
@@ -77,7 +77,7 @@ class GravityView_Render_Settings {
 				$field_options['lightbox'],
 				[
 					'requires' => 'show_as_link',
-					'priority' => 101,
+					'priority' => 51,
 					'context'  => [ 'multiple' ],
 				]
 			);
@@ -88,7 +88,7 @@ class GravityView_Render_Settings {
 				$field_options['new_window'],
 				[
 					'requires' => 'show_as_link',
-					'priority' => 102,
+					'priority' => 52,
 					'context'  => [ 'multiple' ],
 				]
 			);
@@ -130,7 +130,7 @@ class GravityView_Render_Settings {
 
 			if ( 'show_as_link' === $key ) {
 				$_group                   = 'display';
-				$field_option['priority'] = 100;
+				$field_option['priority'] = 50;
 			}
 
 			$option_groups[ $_group ][ $key ] = $field_option;

--- a/includes/admin/metaboxes/views/gravityview-content.php
+++ b/includes/admin/metaboxes/views/gravityview-content.php
@@ -25,7 +25,7 @@ foreach ( $metaboxes as $metabox ) {
 	echo '<div id="' . esc_attr( $metabox->id ) . '">';
 
 	/**
-	 * Can be used to insert additional HTML inside the <div> before the metabox is rendered.
+	 * Can be used to insert additional HTML inside the div before the metabox is rendered.
 	 *
 	 * @since  2.26
 	 *
@@ -38,7 +38,7 @@ foreach ( $metaboxes as $metabox ) {
 	$metabox->render( $post );
 
 	/**
-	 * Can be used to insert additional HTML inside the <div> after the metabox is rendered.
+	 * Can be used to insert additional HTML inside the div after the metabox is rendered.
 	 *
 	 * @since  2.26
 	 *

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -976,7 +976,7 @@ function gv_container_class( $passed_css_class = '', $echo = true, $context = nu
 	$css_class = trim( $passed_css_class . ' ' . $default_css_class );
 
 	/**
-	 * Modify the CSS class to be added to the wrapper <div> of a View.
+	 * Modify the CSS class to be added to the wrapper div of a View.
      *
 	 * @since 1.5.4
 	 * @param string $css_class Default: `gv-container gv-container-{view id}`. If View is hidden until search, adds ` hidden`. If the View has no results, adds `gv-container-no-results`
@@ -1295,7 +1295,7 @@ function gravityview_before() {
 	}
 
 	/**
-	 * Prepend content to the View container `<div>`.
+	 * Prepend content to the View container div.
      *
 	 * @deprecated Use `gravityview/template/before`.
 	 * @param int $view_id The ID of the View being displayed
@@ -1313,7 +1313,7 @@ function gravityview_header() {
 		$gravityview = reset( $args );
 		if ( $gravityview instanceof \GV\Template_Context ) {
 			/**
-			 * Prepend content to the View container <div>.
+			 * Prepend content to the View container div.
 			 *
 			 * @param \GV\Template_Context $gravityview The $gravityview object available in templates.
 			 */
@@ -1327,7 +1327,7 @@ function gravityview_header() {
 	}
 
 	/**
-	 * Prepend content to the View container `<div>`.
+	 * Prepend content to the View container div.
      *
 	 * @deprecated Use `gravityview/template/header`.
 	 * @param int $view_id The ID of the View being displayed
@@ -1345,7 +1345,7 @@ function gravityview_footer() {
 		$gravityview = reset( $args );
 		if ( $gravityview instanceof \GV\Template_Context ) {
 			/**
-			 * Prepend outside the View container <div>.
+			 * Prepend outside the View container div.
 			 *
 			 * @param \GV\Template_Context $gravityview The $gravityview object available in templates.
 			 */
@@ -1359,7 +1359,7 @@ function gravityview_footer() {
 	}
 
 	/**
-	 * Display content after a View. Used to render footer widget areas. Rendered outside the View container `<div>`.
+	 * Display content after a View. Used to render footer widget areas. Rendered outside the View container div.
      *
 	 * @deprecated Use `gravityview/template/footer`.
 	 * @param int $view_id The ID of the View being displayed
@@ -1389,7 +1389,7 @@ function gravityview_after() {
 	}
 
 	/**
-	 * Append content to the View container `<div>`.
+	 * Append content to the View container div.
      *
 	 * @deprecated Use `gravityview/template/after`
 	 * @param int $view_id The ID of the View being displayed

--- a/includes/class-frontend-views.php
+++ b/includes/class-frontend-views.php
@@ -1113,8 +1113,8 @@ class GravityView_frontend {
 		 * Filter the entries output to the View.
 		 *
 		 * @deprecated since 1.5.2
+		 * @param array $entries Array of entries to be displayed
 		 * @param array $args View settings associative array
-		 * @var array
 		 */
 		$entries = apply_filters( 'gravityview_view_entries', $entries, $args );
 

--- a/includes/class-gravityview-entry-approval.php
+++ b/includes/class-gravityview-entry-approval.php
@@ -662,7 +662,7 @@ class GravityView_Entry_Approval {
 		$action = GravityView_Entry_Approval_Status::get_key( $new_status );
 
 		/**
-		 * Triggered when an entry approval is set. {$action} can be 'approved', 'unapproved', or 'disapproved'.
+		 * Triggered when an entry approval is set. The action value can be 'approved', 'unapproved', or 'disapproved'.
 		 * Note: If you want this to work with Bulk Actions, run in a plugin rather than a theme; the bulk updates hook runs before themes are loaded.
 		 *
 		 * @since 1.7.6.1

--- a/includes/class-template.php
+++ b/includes/class-template.php
@@ -981,7 +981,7 @@ class GravityView_View extends \GV\Gamajo_Template_Loader {
 		}
 
 		/**
-		 * The CSS class applied to the widget container `<div>`.
+		 * The CSS class applied to the widget container div.
 		 *
 		 * @since 1.16.2
 		 * @param string $css_class Default: `gv-grid gv-widgets-{zone}` where `{zone}` is replaced by the current `$zone` value. If the View has no results, adds ` gv-widgets-no-results`

--- a/includes/extensions/delete-entry/class-delete-entry.php
+++ b/includes/extensions/delete-entry/class-delete-entry.php
@@ -614,7 +614,7 @@ final class GravityView_Delete_Entry {
 		 * @since 1.15.2
 		 * @see wp_verify_nonce()
 		 * @param int|boolean $valid False if invalid; 1 or 2 when nonce was generated
-		 * @param string $nonce_key Name of nonce action used in wp_verify_nonce. $_GET['delete'] holds the nonce value itself. Default: `delete_{entry_id}`
+		 * @param string $nonce_key Name of nonce action used in wp\_verify\_nonce. The $\_GET['delete'] value holds the nonce value itself. Default: delete_{entry_id}
 		 */
 		$valid = apply_filters( 'gravityview/delete-entry/verify_nonce', $valid, $nonce_key );
 

--- a/includes/extensions/duplicate-entry/class-duplicate-entry.php
+++ b/includes/extensions/duplicate-entry/class-duplicate-entry.php
@@ -590,7 +590,7 @@ final class GravityView_Duplicate_Entry {
 		 * @since 2.5
 		 * @see wp_verify_nonce()
 		 * @param int|boolean $valid False if invalid; 1 or 2 when nonce was generated
-		 * @param string $nonce_key Name of nonce action used in wp_verify_nonce. $_GET['duplicate'] holds the nonce value itself. Default: `duplicate_{entry_id}`
+		 * @param string $nonce_key Name of nonce action used in wp\_verify\_nonce. The $\_GET['duplicate'] value holds the nonce value itself. Default: duplicate_{entry_id}
 		 */
 		$valid = apply_filters( 'gravityview/duplicate-entry/verify_nonce', $valid, $nonce_key );
 

--- a/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
+++ b/includes/extensions/lightbox-entry/class-gravityview-lightbox-entry.php
@@ -587,7 +587,7 @@ class GravityView_Lightbox_Entry {
 			<head>
 				<?php
 				/**
-				 * Fires after <head> tag.
+				 * Fires after the opening head tag.
 				 *
 				 * @action `gk/gravityview/lightbox/entry/output/head-before`
 				 *
@@ -615,7 +615,7 @@ class GravityView_Lightbox_Entry {
 
 				<?php
 				/**
-				 * Fires before </head> tag.
+				 * Fires before the closing head tag.
 				 *
 				 * @action `gk/gravityview/lightbox/entry/output/head-after`
 				 *
@@ -633,7 +633,7 @@ class GravityView_Lightbox_Entry {
 			<body>
 				<?php
 				/**
-				 * Fires after <body> tag before the content is rendered.
+				 * Fires after the body tag before the content is rendered.
 				 *
 				 * @action `gk/gravityview/lightbox/entry/output/content-before`
 				 *
@@ -651,7 +651,7 @@ class GravityView_Lightbox_Entry {
 
 				<?php
 				/**
-				 * Fires inside the <body> tag after the content is rendered and before the footer.
+				 * Fires inside the body tag after the content is rendered and before the footer.
 				 *
 				 * @action `gk/gravityview/lightbox/entry/output/content-after`
 				 *
@@ -669,7 +669,7 @@ class GravityView_Lightbox_Entry {
 
 				<?php
 				/**
-				 * Fires after the footer and before the closing </body> tag.
+				 * Fires after the footer and before the closing body tag.
 				 *
 				 * @action `gk/gravityview/lightbox/entry/output/footer-after`
 				 *

--- a/includes/fields/class-gravityview-field-list.php
+++ b/includes/fields/class-gravityview-field-list.php
@@ -12,7 +12,6 @@
  * @since 1.14
  */
 class GravityView_Field_List extends GravityView_Field {
-
 	var $name = 'list';
 
 	/**
@@ -47,6 +46,8 @@ class GravityView_Field_List extends GravityView_Field {
 		add_filter( 'gravityview/common/get_form_fields', array( $this, 'add_form_fields' ), 10, 3 );
 
 		add_filter( 'gravityview/search/searchable_fields', array( $this, 'remove_columns_from_searchable_fields' ), 10 );
+
+		add_filter( 'gravityview/merge_tags/modifiers/value', array( $this, 'handle_list_column_modifier' ), 10, 6 );
 	}
 
 	/**
@@ -233,6 +234,42 @@ class GravityView_Field_List extends GravityView_Field {
 		$columns = wp_list_pluck( $field->choices, 'text' );
 
 		return isset( $columns[ $column_id ] ) ? $columns[ $column_id ] : $backup_label;
+	}
+
+	/**
+	 * Handles List field column modifiers (e.g., `{List:10:2}` where "2" is the column number).
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $return    The current merge tag value to be filtered.
+	 * @param string   $raw_value The raw value submitted for this field. May be CSV or JSON-encoded.
+	 * @param string   $value     The original merge tag value, passed from Gravity Forms
+	 * @param string   $merge_tag If the merge tag being executed is an individual field merge tag (i.e. {Name:3}), this variable will contain the field's ID. If not, this variable will contain the name of the merge tag (i.e. all_fields).
+	 * @param string   $modifier  The string containing any modifiers for this merge tag. For example, "maxwords:10" would be the modifiers for the following merge tag: `{Text:2:maxwords:10}`.
+	 * @param GF_Field $field     The current field.
+	 *
+	 * @return string
+	 */
+	public function handle_list_column_modifier( $return, $raw_value, $value, $merge_tag, $modifier, $field ) {
+		// Only process for List fields with columns enabled.
+		if ( ! $field instanceof GF_Field_List || ! $field->enableColumns ) {
+			return $return;
+		}
+
+		[ $column, $format ] = array_pad( explode( ':', $modifier, 2 ), 2, null );
+
+		if ( ! is_numeric( $column ) ) {
+			return $return;
+		}
+
+		$column_id    = (int) $modifier;
+		$column_value = self::column_value( $field, $raw_value, $column_id, $format ?: 'html' );
+
+		if ( null !== $column_value ) {
+			return $column_value;
+		}
+
+		return $return;
 	}
 }
 

--- a/includes/fields/class-gravityview-field-list.php
+++ b/includes/fields/class-gravityview-field-list.php
@@ -239,7 +239,7 @@ class GravityView_Field_List extends GravityView_Field {
 	/**
 	 * Handles List field column modifiers (e.g., `{List:10:2}` where "2" is the column number).
 	 *
-	 * @since TBD
+	 * @since 2.46.0
 	 *
 	 * @param string   $return    The current merge tag value to be filtered.
 	 * @param string   $raw_value The raw value submitted for this field. May be CSV or JSON-encoded.

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -5,6 +5,52 @@
  * @since 1.12
  */
 
+/**
+ * Returns the current shortcode tag being executed.
+ *
+ * @since 2.45.1
+ *
+ * @param string $op  Operation: 'push' to add a tag, 'pop' to remove, 'top' to get current.
+ * @param string $tag Shortcode tag to push (only used with 'push' operation).
+ *
+ * @return string|null Current shortcode tag or null if stack is empty.
+ */
+if ( ! function_exists( 'gv_current_shortcode_tag' ) ) {
+	function gv_current_shortcode_tag( $op = 'top', $tag = null ) {
+		static $stack = [];
+
+		switch ( $op ) {
+			case 'push':
+				if ( is_string( $tag ) && '' !== $tag ) {
+					$stack[] = $tag;
+				}
+
+				return end( $stack ) ?: null;
+			case 'pop':
+				array_pop( $stack );
+
+				return end( $stack ) ?: null;
+			default:
+				return end( $stack ) ?: null;
+		}
+	}
+
+	if ( function_exists( 'add_filter' ) ) {
+		add_filter( 'pre_do_shortcode_tag', function ( $return, $tag ) {
+			if ( false === $return ) {
+				gv_current_shortcode_tag( 'push', $tag );
+			}
+
+			return $return;
+		}, 10, 2 );
+
+		add_filter( 'do_shortcode_tag', function ( $output, $tag ) {
+			gv_current_shortcode_tag( 'pop' );
+
+			return $output;
+		}, 10, 2 );
+	}
+}
 
 /**
  * Get the URL for a CSS file

--- a/includes/widgets/search-widget/templates/search-field-link.php
+++ b/includes/widgets/search-widget/templates/search-field-link.php
@@ -32,7 +32,7 @@ $links_label = apply_filters( 'gravityview/extension/search/links_label', $links
 /**
  * Change what separates search bar "Link" input type links.
  *
- * @param string $links_sep Default: `&nbsp;|&nbsp;` Used to connect multiple links
+ * @param string $links_sep Default: " | " (spaces are non-breaking space html entities) Used to connect multiple links
  */
 $links_sep = apply_filters( 'gravityview/extension/search/links_sep', '&nbsp;|&nbsp;' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,17 +21,21 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
-= develop =
+= 2.46 on September 4, 2025 =
+
+This release adds the ability to output column values from multi-column List fields using merge tag modifiers, notifies admins when users access pages with misconfigured shortcode secrets, and fixes issues with Checkbox field settings, Result Number sequencing, and a potential PHP error with Address fields.
 
 #### 🚀 Added
 * Support for the List field merge tag modifier (e.g., `{List:1:2:text}`), enabling output of column values as an HTML list (default) or as a comma-separated string.
-
-#### ✨ Improved
 * An admin notice is displayed when a GravityView shortcode’s required `secret` attribute is missing or invalid.
 
 #### 🐛 Fixed
 * Display issue with Checkbox field settings in the View editor where related "Link to single entry" options were not grouped together.
 * Result Number field now respects the "First Number in the Sequence" setting instead of always starting at 0.
+* PHP fatal error that could occur when editing entries containing Address fields.
+
+#### 🔧 Updated
+* [Foundation](https://www.gravitykit.com/foundation/) to version 1.3.1, fixing an unrelated product dependency notice shown when installing certain products from the Manage Your Kit screen.
 
 = 2.45 on August 28, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+#### 🐛 Fixed
+* Display issue with Checkbox field settings in the View editor where related "Link to single entry" options were not grouped together.
+
 = 2.45 on August 28, 2025 =
 
 This release introduces a new 4-column Layout Builder option and lightbox support for the `[gv_entry_link]` shortcode, improves performance by disabling secure links for File Upload fields, and resolves various issues with filters, notifications, and file display on the Edit Entry screen.

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 = develop =
 
+#### 🚀 Added
+* Support for the List field merge tag modifier (e.g., `{List:1:2:text}`), enabling output of column values as an HTML list (default) or as a comma-separated string.
+
 #### 🐛 Fixed
 * Display issue with Checkbox field settings in the View editor where related "Link to single entry" options were not grouped together.
 

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 #### 🐛 Fixed
 * Display issue with Checkbox field settings in the View editor where related "Link to single entry" options were not grouped together.
+* Result Number field now respects the "First Number in the Sequence" setting instead of always starting at 0.
 
 = 2.45 on August 28, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 #### 🚀 Added
 * Support for the List field merge tag modifier (e.g., `{List:1:2:text}`), enabling output of column values as an HTML list (default) or as a comma-separated string.
 
+#### ✨ Improved
+* An admin notice is displayed when a GravityView shortcode’s required `secret` attribute is missing or invalid.
+
 #### 🐛 Fixed
 * Display issue with Checkbox field settings in the View editor where related "Link to single entry" options were not grouped together.
 * Result Number field now respects the "First Number in the Sequence" setting instead of always starting at 0.

--- a/templates/deprecated/fields/email.php
+++ b/templates/deprecated/fields/email.php
@@ -59,7 +59,7 @@ if ( ! isset( $field_settings['emailmailto'] ) || ! empty( $field_settings['emai
  * Prevent encrypting emails no matter what - this is handy for DataTables exports, for example
  *
  * @since 1.1.6
- * @var boolean
+ * @param boolean $prevent_encrypt Whether to prevent email encryption
  */
 $prevent_encrypt = apply_filters( 'gravityview_email_prevent_encrypt', false );
 

--- a/templates/deprecated/fields/post_image.php
+++ b/templates/deprecated/fields/post_image.php
@@ -102,7 +102,7 @@ $image = new GravityView_Image( $image_atts );
  * Modify the values used for the image meta.
  *
  * @see https://www.gravitykit.com/support/documentation/201606759 Read more about the filter
- * @var array $image_meta Associative array with `title`, `caption`, and `description` keys, each an array with `label`, `value`, `tag_label` and `tag_value` keys
+ * @param array $image_meta Associative array with `title`, `caption`, and `description` keys, each an array with `label`, `value`, `tag_label` and `tag_value` keys
  */
 $image_meta = apply_filters(
 	'gravityview_post_image_meta',
@@ -135,7 +135,7 @@ $wrappertag = 'figure';
  * Whether to show labels for the image meta.
  *
  * @see https://www.gravitykit.com/support/documentation/201606759 Read more about the filter
- * @var boolean $showlabels True: Show labels; False: hide labels
+ * @param boolean $showlabels True: Show labels; False: hide labels
  */
 $showlabels = apply_filters( 'gravityview_post_image_meta_show_labels', true );
 

--- a/templates/deprecated/list-body.php
+++ b/templates/deprecated/list-body.php
@@ -129,7 +129,7 @@ if ( ! $this->getTotalEntries() ) {
 				<?php
 
 				/**
-				 * Tap in inside the View Content wrapper <div>.
+				 * Tap in inside the View Content wrapper div.
 				 *
 				 * @param array $entry Gravity Forms Entry array
 				 * @param \GravityView_View $this The GravityView_View instance
@@ -156,7 +156,7 @@ if ( ! $this->getTotalEntries() ) {
 				);
 
 				/**
-				 * Tap in at the end of the View Content wrapper <div>.
+				 * Tap in at the end of the View Content wrapper div.
 				 *
 				 * @param array $entry Gravity Forms Entry array
 				 * @param \GravityView_View $this The GravityView_View instance

--- a/templates/fields/field-email-html.php
+++ b/templates/fields/field-email-html.php
@@ -67,9 +67,8 @@ if ( ! isset( $field_settings['emailmailto'] ) || ! empty( $field_settings['emai
 * @since 1.1.6
 *
 * @since 2.0
-* @param \GV\Template_Context The $gravityview template context object.
-*
-* @var boolean
+* @param boolean $prevent_encrypt Whether to prevent email encryption
+* @param \GV\Template_Context $gravityview The $gravityview template context object
 */
 $prevent_encrypt = apply_filters( 'gravityview_email_prevent_encrypt', false, $gravityview );
 

--- a/templates/fields/field-post_image-html.php
+++ b/templates/fields/field-post_image-html.php
@@ -107,7 +107,7 @@ $image = new GravityView_Image( $image_atts );
  * Modify the values used for the image meta.
  *
  * @see https://www.gravitykit.com/support/documentation/201606759 Read more about the filter
- * @var array $image_meta Associative array with `title`, `caption`, and `description` keys, each an array with `label`, `value`, `tag_label` and `tag_value` keys
+ * @param array $image_meta Associative array with `title`, `caption`, and `description` keys, each an array with `label`, `value`, `tag_label` and `tag_value` keys
  */
 $image_meta = apply_filters(
 	'gravityview_post_image_meta',
@@ -140,7 +140,7 @@ $wrappertag = 'figure';
  * Whether to show labels for the image meta.
  *
  * @see https://www.gravitykit.com/support/documentation/201606759 Read more about the filter
- * @var boolean $showlabels True: Show labels; False: hide labels
+ * @param boolean $showlabels True: Show labels; False: hide labels
  */
 $showlabels = apply_filters( 'gravityview_post_image_meta_show_labels', true );
 

--- a/templates/fields/field-sequence.php
+++ b/templates/fields/field-sequence.php
@@ -13,4 +13,10 @@ if ( ! isset( $gravityview ) || empty( $gravityview->template ) ) {
 
 $field_settings = $gravityview->field->as_configuration();
 
+// Set the field's start number from field settings.
+$gravityview->field->start = is_numeric( $field_settings['start'] ?? null ) ? (int) $field_settings['start'] : 1;
+
+// Set the field's reverse setting from field settings  .
+$gravityview->field->reverse = ! empty( $field_settings['reverse'] );
+
 echo $gravityview->field->field->get_sequence( $gravityview );

--- a/tests/unit-tests/GravityView_Edit_Entry_Test.php
+++ b/tests/unit-tests/GravityView_Edit_Entry_Test.php
@@ -2612,7 +2612,7 @@ class GravityView_Edit_Entry_Test extends GV_UnitTestCase {
 	 * Test that Address field with empty string value doesn't cause PHP errors
 	 * Tests the fix for: PHP Fatal error: Cannot assign an empty string to a string offset
 	 * 
-	 * @since TODO
+	 * @since 2.46.0
 	 * @covers GravityView_Edit_Entry_Render::get_field_value
 	 */
 	public function test_address_field_empty_string_fix() {

--- a/translations.pot
+++ b/translations.pot
@@ -9,14 +9,13 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-29T00:38:18+00:00\n"
+"POT-Creation-Date: 2025-09-04T14:56:53-04:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.10.0\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: gk-gravityview\n"
 
 #. Plugin Name of the plugin
-#: gravityview.php
 #: future/includes/gutenberg/class-gv-gutenberg-blocks.php:165
 #: includes/class-gravityview-admin-bar.php:60
 #: includes/class-gravityview-roles-capabilities.php:149
@@ -26,17 +25,14 @@ msgstr ""
 
 #. Plugin URI of the plugin
 #. Author URI of the plugin
-#: gravityview.php
 msgid "https://www.gravitykit.com"
 msgstr ""
 
 #. Description of the plugin
-#: gravityview.php
 msgid "The best, easiest way to display Gravity Forms entries on your website."
 msgstr ""
 
 #. Author of the plugin
-#: gravityview.php
 #: vendor_prefixed/gravitykit/foundation/src/Licenses/WP/PluginsPage.php:409
 #: vendor_prefixed/gravitykit/foundation/src/WP/AdminMenu.php:198
 #: vendor_prefixed/gravitykit/foundation/src/WP/AdminMenu.php:199
@@ -1126,12 +1122,28 @@ msgstr ""
 msgid "View Details"
 msgstr ""
 
-#: future/includes/class-gv-shortcode.php:191
-msgid "%1$s: Invalid View secret provided."
+#: future/includes/class-gv-shortcode.php:192
+msgid "%1$s: Invalid View secret provided. Update the shortcode with the secret: %2$s"
 msgstr ""
 
-#: future/includes/class-gv-shortcode.php:200
-msgid "%1$s: Invalid View secret provided. Update the shortcode with the secret: %2$s"
+#: future/includes/class-gv-shortcode.php:210
+msgid "this page"
+msgstr ""
+
+#: future/includes/class-gv-shortcode.php:221
+msgid "shortcode"
+msgstr ""
+
+#: future/includes/class-gv-shortcode.php:222
+msgid "A GravityView shortcode"
+msgstr ""
+
+#: future/includes/class-gv-shortcode.php:224
+msgid "[shortcode] on [page_link] is missing or has an invalid \"secret\" attribute."
+msgstr ""
+
+#: future/includes/class-gv-shortcode.php:255
+msgid "%1$s: Invalid View secret provided."
 msgstr ""
 
 #: future/includes/class-gv-view.php:173
@@ -4349,7 +4361,7 @@ msgstr ""
 msgid "There was an error updating the entry."
 msgstr ""
 
-#: includes/fields/class-gravityview-field-list.php:41
+#: includes/fields/class-gravityview-field-list.php:40
 #: includes/presets/default-list/class-gravityview-default-template-list.php:16
 msgid "List"
 msgstr ""
@@ -6462,7 +6474,7 @@ msgctxt "Indicates \"time ago\""
 msgid "ago"
 msgstr ""
 
-#: vendor_prefixed/gravitykit/foundation/src/Licenses/ProductDependencyChecker.php:341
+#: vendor_prefixed/gravitykit/foundation/src/Licenses/ProductDependencyChecker.php:344
 msgctxt "Placeholders inside [] are not to be translated."
 msgid "Product with '[text_domain]' text domain"
 msgstr ""
@@ -8253,84 +8265,4 @@ msgstr ""
 #: future/includes/gutenberg/build/view.js:1
 #: future/includes/gutenberg/shared/js/sort-selector.js:75
 msgid "No Sorting Fields found"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-field/block.json
-msgctxt "block title"
-msgid "GravityView Entry Field"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-field/block.json
-msgctxt "block description"
-msgid "Display an entry field value."
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-field/block.json
-#: future/includes/gutenberg/blocks/entry-link/block.json
-#: future/includes/gutenberg/blocks/entry/block.json
-#: future/includes/gutenberg/blocks/view-details/block.json
-#: future/includes/gutenberg/blocks/view/block.json
-msgctxt "block keyword"
-msgid "GravityView"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-field/block.json
-#: future/includes/gutenberg/blocks/entry-link/block.json
-#: future/includes/gutenberg/blocks/entry/block.json
-#: future/includes/gutenberg/blocks/view-details/block.json
-msgctxt "block keyword"
-msgid "form entry"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-field/block.json
-#: future/includes/gutenberg/blocks/entry-link/block.json
-#: future/includes/gutenberg/blocks/entry/block.json
-#: future/includes/gutenberg/blocks/view-details/block.json
-msgctxt "block keyword"
-msgid "entry"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-link/block.json
-msgctxt "block title"
-msgid "GravityView Entry Link"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry-link/block.json
-msgctxt "block description"
-msgid "Display a link to the GravityView entry."
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry/block.json
-msgctxt "block title"
-msgid "GravityView Entry"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/entry/block.json
-msgctxt "block description"
-msgid "Display a GravityView entry."
-msgstr ""
-
-#: future/includes/gutenberg/blocks/view-details/block.json
-msgctxt "block title"
-msgid "GravityView View Details"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/view-details/block.json
-msgctxt "block description"
-msgid "Display specific information about a GravityView View."
-msgstr ""
-
-#: future/includes/gutenberg/blocks/view/block.json
-msgctxt "block title"
-msgid "GravityView View"
-msgstr ""
-
-#: future/includes/gutenberg/blocks/view/block.json
-msgctxt "block description"
-msgid "Display a GravityView View."
-msgstr ""
-
-#: future/includes/gutenberg/blocks/view/block.json
-msgctxt "block keyword"
-msgid "view"
 msgstr ""


### PR DESCRIPTION
This release adds the ability to output column values from multi-column List fields using merge tag modifiers, notifies admins when users access pages with misconfigured shortcode secrets, and fixes issues with Checkbox field settings, Result Number sequencing, and a potential PHP error with Address fields.

#### 🚀 Added
* Support for the List field merge tag modifier (e.g., `{List:1:2:text}`), enabling output of column values as an HTML list (default) or as a comma-separated string.
* An admin notice is displayed when a GravityView shortcode’s required `secret` attribute is missing or invalid.

#### 🐛 Fixed
* Display issue with Checkbox field settings in the View editor where related "Link to single entry" options were not grouped together.
* Result Number field now respects the "First Number in the Sequence" setting instead of always starting at 0.
* PHP fatal error that could occur when editing entries containing Address fields.

#### 🔧 Updated
* [Foundation](https://www.gravitykit.com/foundation/) to version 1.3.1, fixing an unrelated product dependency notice shown when installing certain products from the Manage Your Kit screen.


💾 [Build file](https://www.dropbox.com/scl/fi/ypmuo36jyvqrrf7hv312t/gravityview-2.46-f6909ddab.zip?rlkey=uf6f7wtss6a2qfgdvwn17aued&dl=1) (f6909ddab).