### PR TITLE
Add secret attribute support to Entry Link block

### DIFF
--- a/future/includes/gutenberg/blocks/entry-link/block.json
+++ b/future/includes/gutenberg/blocks/entry-link/block.json
@@ -58,6 +58,10 @@
     "showPreviewImage": {
       "type": "boolean",
       "default": false
+    },
+    "secret": {
+      "type": "string",
+      "default": null
     }
   },
   "example": {

--- a/future/includes/gutenberg/blocks/entry-link/block.php
+++ b/future/includes/gutenberg/blocks/entry-link/block.php
@@ -47,6 +47,7 @@ class EntryLink {
 			'linkAtts'     => 'link_atts',
 			'fieldValues'  => 'field_values',
 			'content'      => 'content',
+			'secret'       => 'secret',
 		);
 
 		$shortcode_attributes = array();

--- a/future/includes/gutenberg/blocks/entry-link/edit.js
+++ b/future/includes/gutenberg/blocks/entry-link/edit.js
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { Panel, PanelBody, SelectControl, TextControl } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 
 import ViewSelector from 'shared/js/view-selector';
 import EntrySelector from 'shared/js/entry-selector';
@@ -23,10 +24,21 @@ export default function Edit( { attributes, setAttributes, name: blockName } ) {
 		fieldValues,
 		action,
 		content,
+		secret,
 		previewBlock,
 		previewAsShortcode,
 		showPreviewImage
 	} = attributes;
+
+	// For blocks saved before the secret attribute was added, populate it from the View data.
+	useEffect( () => {
+		if ( viewId && !secret && gkGravityViewBlocks?.views ) {
+			const selectedView = gkGravityViewBlocks.views.find( option => option.value === viewId );
+			if ( selectedView && selectedView.secret ) {
+				setAttributes( { secret: selectedView.secret } );
+			}
+		}
+	}, [ viewId, secret ] );
 
 	const previewImage = gkGravityViewBlocks[ blockName ]?.previewImage && <img className="preview-image" src={ gkGravityViewBlocks[ blockName ]?.previewImage } alt={ __( 'Block preview image.', 'gk-gravityview' ) } />;
 
@@ -49,7 +61,15 @@ export default function Edit( { attributes, setAttributes, name: blockName } ) {
 							<ViewSelector
 								viewId={ viewId }
 								isSidebar={ true }
-								onChange={ ( viewId ) => setAttributes( { viewId, previewBlock: false, entryId: '' } ) }
+								onChange={ ( viewId ) => {
+									const selectedView = gkGravityViewBlocks.views.find( option => option.value === viewId );
+									setAttributes( {
+										viewId,
+										secret: selectedView?.secret,
+										previewBlock: false,
+										entryId: ''
+									} );
+								} }
 							/>
 
 							<EntrySelector
@@ -136,7 +156,15 @@ export default function Edit( { attributes, setAttributes, name: blockName } ) {
 
 					<ViewSelector
 						viewId={ viewId }
-						onChange={ ( viewId ) => setAttributes( { viewId, previewBlock: false, entryId: '' } ) }
+						onChange={ ( viewId ) => {
+							const selectedView = gkGravityViewBlocks.views.find( option => option.value === viewId );
+							setAttributes( {
+								viewId,
+								secret: selectedView?.secret,
+								previewBlock: false,
+								entryId: ''
+							} );
+						} }
 					/>
 
 					<EntrySelector

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 
 == Changelog ==
 
+= develop =
+
+#### 🐛 Fixed
+* Entry Link block not working with secure Views that require a secret.
+
 = 2.46.1 on September 11, 2025 =
 
 This update fixes widget display issues when embedding Views with page builders.


### PR DESCRIPTION
This implements #2460.

Before installing, add the Entry Link block using version 2.46.1 and confirm that it fails to display the link. Then install the latest build and test the following:

1) Re-save the page with the existing block (without changing any options) and confirm that the link now displays correctly.
2) Add a new Entry Link block and confirm that it works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entry Link block now supports secure Views by accepting a secret, ensuring links work with protected content.
  * Selecting a View in the editor auto-populates the secret; existing blocks are backfilled when possible.

* **Bug Fixes**
  * Resolved issues where the Entry Link block failed with Views requiring a secret.

* **Documentation**
  * Changelog updated with a development note about the Entry Link fix and a recent patch release entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/hg825famnaryy05g85rt6/gravityview-2.46.1-5d5b71a62.zip?rlkey=tfqbi9k4kjenhu4j8cr2bp2cv&dl=1) (5d5b71a62).