### PR TITLE
Fix search filters preventing single entry pages from displaying

### DIFF
--- a/future/includes/class-gv-renderer-view.php
+++ b/future/includes/class-gv-renderer-view.php
@@ -36,6 +36,9 @@ class View_Renderer extends Renderer {
 			return null;
 		}
 
+		// Track that we're rendering this View.
+		\GV\View::push_rendering( $view->ID );
+
 		/**
 		 * Modify the template slug about to be loaded in directory views.
 		 *
@@ -93,7 +96,11 @@ class View_Renderer extends Renderer {
 				 */
 				add_action( 'gravityview_before', $this->legacy_template_warning( $view, $path ) );
 
-				return $override->render( $template_slug );
+				$result = $override->render( $template_slug );
+
+				\GV\View::pop_rendering();
+
+				return $result;
 			}
 		}
 
@@ -213,6 +220,11 @@ class View_Renderer extends Renderer {
 		remove_filter( 'gravityview/widget/search/form/action', $add_search_action_filter );
 
 		\GV\Mocks\Legacy_Context::pop();
-		return ob_get_clean();
+
+		$output = ob_get_clean();
+
+		\GV\View::pop_rendering();
+
+		return $output;
 	}
 }

--- a/future/includes/class-gv-renderer-view.php
+++ b/future/includes/class-gv-renderer-view.php
@@ -39,192 +39,193 @@ class View_Renderer extends Renderer {
 		// Track that we're rendering this View.
 		\GV\View::push_rendering( $view->ID );
 
-		/**
-		 * Modify the template slug about to be loaded in directory views.
-		 *
-		 * @since 1.6
-		 * @deprecated
-		 * @see The `gravityview_get_template_id` filter
-		 * @param string $slug Default: 'table'
-		 * @param string $view The current view context: directory.
-		 */
-		$template_slug = apply_filters( 'gravityview_template_slug_' . $view->settings->get( 'template' ), 'table', 'directory' );
-
-		/**
-		 * Figure out whether to get the entries or not.
-		 *
-		 * Some contexts don't need initial entries, like the DataTables directory type.
-		 *
-		 * Whether to get the entries or not.
-		 *
-		 * @param boolean $get_entries Get entries or not, default: true.
-		 */
-		$get_entries = apply_filters( 'gravityview_get_view_entries_' . $template_slug, true );
-
-		$hide_until_searched = $view->settings->get( 'hide_until_searched' );
-
-		/**
-		 * Hide View data until search is performed.
-		 */
-		$get_entries = ( $hide_until_searched && ! $request->is_search() ) ? false : $get_entries;
-
-		/**
-		 * Fetch entries for this View.
-		 */
-		if ( $get_entries ) {
-			$entries = $view->get_entries( $request );
-		} else {
-			$entries = new \GV\Entry_Collection();
-		}
-
-		/**
-		 * Load a legacy override template if exists.
-		 */
-		$override = new \GV\Legacy_Override_Template( $view, null, null, $request );
-		foreach ( array( 'header', 'body', 'footer' ) as $part ) {
-
-			$path = $override->get_template_part( $template_slug, $part );
-
-			if ( $path && false === strpos( $path, '/deprecated' ) ) {
-				/**
-				 * We have to bail and call the legacy renderer. Crap!
-				 */
-				gravityview()->log->notice( 'Legacy templates detected in theme {path}', array( 'path' => $path ) );
-
-				/**
-				 * Show a warning at the top, if View is editable by the user.
-				 */
-				add_action( 'gravityview_before', $this->legacy_template_warning( $view, $path ) );
-
-				$result = $override->render( $template_slug );
-
-				\GV\View::pop_rendering();
-
-				return $result;
-			}
-		}
-
-		/**
-		 * Filter the template class that is about to be used to render the view.
-		 *
-		 * @since 2.0
-		 * @param string $class The chosen class - Default: \GV\View_Table_Template.
-		 * @param View $view The view about to be rendered.
-		 * @param \GV\Request $request The associated request.
-		 */
-		$class = apply_filters( 'gravityview/template/view/class', sprintf( '\GV\View_%s_Template', ucfirst( $template_slug ) ), $view, $request );
-		if ( ! $class || ! class_exists( $class ) ) {
-			gravityview()->log->notice( '{template_class} not found, falling back to legacy', array( 'template_class' => $class ) );
-			$class = '\GV\View_Legacy_Template';
-		}
-
-		/** @var \GV\View_Table_Template|\GV\View_List_Template|\GV\View_Legacy_Template $template */
-		$template = new $class( $view, $entries, $request );
-
-		/**
-		 * @var [] $counter A counter incrementing each time a View is rendered.
-		 * @since 2.15
-		 * @usedby `gravityview/template/view/render` filter
-		 */
-		static $counter = array();
-
-		$counter[ $view->ID ] = isset( $counter[ $view->ID ] ) ? $counter[ $view->ID ] + 1 : 1;
-
-		/**
-		 * Updates the View anchor ID each time the View is rendered.
-		 *
-		 * @since 2.15
-		 * @uses {@var $counter}
-		 * @param Template_Context $context
-		 */
-		add_action(
-			'gravityview/template/view/render',
-			$add_anchor_id_filter = function ( $context ) use ( &$counter ) {
-				/** @see \GV\View::set_anchor_id() */
-				$context->view->set_anchor_id( $counter[ $context->view->ID ] );
-			}
-		);
-
-		$add_search_action_filter = function ( $action ) use ( $view ) {
-			return $action . '#' . esc_attr( $view->get_anchor_id() );
-		};
-
-		/**
-		 * Allow appending the View ID anchor to the search URL.
-		 *
-		 * @since  2.15
-		 *
-		 * @param bool   $set_view_id_anchor
-		 */
-		if ( apply_filters( 'gravityview/widget/search/append_view_id_anchor', true ) ) {
+		try {
 			/**
-			 * Append the View anchor ID to the search form action.
+			 * Modify the template slug about to be loaded in directory views.
+			 *
+			 * @since 1.6
+			 * @deprecated
+			 * @see The `gravityview_get_template_id` filter
+			 * @param string $slug Default: 'table'
+			 * @param string $view The current view context: directory.
+			 */
+			$template_slug = apply_filters( 'gravityview_template_slug_' . $view->settings->get( 'template' ), 'table', 'directory' );
+
+			/**
+			 * Figure out whether to get the entries or not.
+			 *
+			 * Some contexts don't need initial entries, like the DataTables directory type.
+			 *
+			 * Whether to get the entries or not.
+			 *
+			 * @param boolean $get_entries Get entries or not, default: true.
+			 */
+			$get_entries = apply_filters( 'gravityview_get_view_entries_' . $template_slug, true );
+
+			$hide_until_searched = $view->settings->get( 'hide_until_searched' );
+
+			/**
+			 * Hide View data until search is performed.
+			 */
+			$get_entries = ( $hide_until_searched && ! $request->is_search() ) ? false : $get_entries;
+
+			/**
+			 * Fetch entries for this View.
+			 */
+			if ( $get_entries ) {
+				$entries = $view->get_entries( $request );
+			} else {
+				$entries = new \GV\Entry_Collection();
+			}
+
+			/**
+			 * Load a legacy override template if exists.
+			 */
+			$override = new \GV\Legacy_Override_Template( $view, null, null, $request );
+			foreach ( array( 'header', 'body', 'footer' ) as $part ) {
+
+				$path = $override->get_template_part( $template_slug, $part );
+
+				if ( $path && false === strpos( $path, '/deprecated' ) ) {
+					/**
+					 * We have to bail and call the legacy renderer. Crap!
+					 */
+					gravityview()->log->notice( 'Legacy templates detected in theme {path}', array( 'path' => $path ) );
+
+					/**
+					 * Show a warning at the top, if View is editable by the user.
+					 */
+					add_action( 'gravityview_before', $this->legacy_template_warning( $view, $path ) );
+
+					$result = $override->render( $template_slug );
+
+					return $result;
+				}
+			}
+
+			/**
+			 * Filter the template class that is about to be used to render the view.
+			 *
+			 * @since 2.0
+			 * @param string $class The chosen class - Default: \GV\View_Table_Template.
+			 * @param View $view The view about to be rendered.
+			 * @param \GV\Request $request The associated request.
+			 */
+			$class = apply_filters( 'gravityview/template/view/class', sprintf( '\GV\View_%s_Template', ucfirst( $template_slug ) ), $view, $request );
+			if ( ! $class || ! class_exists( $class ) ) {
+				gravityview()->log->notice( '{template_class} not found, falling back to legacy', array( 'template_class' => $class ) );
+				$class = '\GV\View_Legacy_Template';
+			}
+
+			/** @var \GV\View_Table_Template|\GV\View_List_Template|\GV\View_Legacy_Template $template */
+			$template = new $class( $view, $entries, $request );
+
+			/**
+			 * @var [] $counter A counter incrementing each time a View is rendered.
+			 * @since 2.15
+			 * @usedby `gravityview/template/view/render` filter
+			 */
+			static $counter = array();
+
+			$counter[ $view->ID ] = isset( $counter[ $view->ID ] ) ? $counter[ $view->ID ] + 1 : 1;
+
+			/**
+			 * Updates the View anchor ID each time the View is rendered.
 			 *
 			 * @since 2.15
-			 *
-			 * @param string $action The search form action URL.
-			 *
-			 * @uses  {@var View $view}
+			 * @uses {@var $counter}
+			 * @param Template_Context $context
 			 */
-			add_filter( 'gravityview/widget/search/form/action', $add_search_action_filter );
-		}
+			add_action(
+				'gravityview/template/view/render',
+				$add_anchor_id_filter = function ( $context ) use ( &$counter ) {
+					/** @see \GV\View::set_anchor_id() */
+					$context->view->set_anchor_id( $counter[ $context->view->ID ] );
+				}
+			);
 
-		/**
-		 * Remove multiple sorting before calling legacy filters.
-		 * This allows us to fake it till we make it.
-		 */
-		$parameters = $view->settings->as_atts();
-		if ( ! empty( $parameters['sort_field'] ) && is_array( $parameters['sort_field'] ) ) {
-			$has_multisort            = true;
-			$parameters['sort_field'] = reset( $parameters['sort_field'] );
-			if ( ! empty( $parameters['sort_direction'] ) && is_array( $parameters['sort_direction'] ) ) {
-				$parameters['sort_direction'] = reset( $parameters['sort_direction'] );
+			$add_search_action_filter = function ( $action ) use ( $view ) {
+				return $action . '#' . esc_attr( $view->get_anchor_id() );
+			};
+
+			/**
+			 * Allow appending the View ID anchor to the search URL.
+			 *
+			 * @since  2.15
+			 *
+			 * @param bool   $set_view_id_anchor
+			 */
+			if ( apply_filters( 'gravityview/widget/search/append_view_id_anchor', true ) ) {
+				/**
+				 * Append the View anchor ID to the search form action.
+				 *
+				 * @since 2.15
+				 *
+				 * @param string $action The search form action URL.
+				 *
+				 * @uses  {@var View $view}
+				 */
+				add_filter( 'gravityview/widget/search/form/action', $add_search_action_filter );
 			}
-		}
 
-		/** @todo Deprecate this! */
-		$parameters = \GravityView_frontend::get_view_entries_parameters( $parameters, $view->form->ID );
+			/**
+			 * Remove multiple sorting before calling legacy filters.
+			 * This allows us to fake it till we make it.
+			 */
+			$parameters = $view->settings->as_atts();
+			if ( ! empty( $parameters['sort_field'] ) && is_array( $parameters['sort_field'] ) ) {
+				$has_multisort            = true;
+				$parameters['sort_field'] = reset( $parameters['sort_field'] );
+				if ( ! empty( $parameters['sort_direction'] ) && is_array( $parameters['sort_direction'] ) ) {
+					$parameters['sort_direction'] = reset( $parameters['sort_direction'] );
+				}
+			}
 
-		global $post;
+			/** @todo Deprecate this! */
+			$parameters = \GravityView_frontend::get_view_entries_parameters( $parameters, $view->form->ID );
 
-		/** Mock the legacy state for the widgets and whatnot */
-		\GV\Mocks\Legacy_Context::push(
-			array_merge(
-				array(
-					'view'    => $view,
-					'entries' => $entries,
-					'request' => $request,
-				),
-				empty( $parameters ) ? array() : array(
-					'paging'  => $parameters['paging'],
-					'sorting' => $parameters['sorting'],
-				),
-				empty( $post ) ? array() : array(
-					'post' => $post,
+			global $post;
+
+			/** Mock the legacy state for the widgets and whatnot */
+			\GV\Mocks\Legacy_Context::push(
+				array_merge(
+					array(
+						'view'    => $view,
+						'entries' => $entries,
+						'request' => $request,
+					),
+					empty( $parameters ) ? array() : array(
+						'paging'  => $parameters['paging'],
+						'sorting' => $parameters['sorting'],
+					),
+					empty( $post ) ? array() : array(
+						'post' => $post,
+					)
 				)
-			)
-		);
+			);
 
-		add_action(
-			'gravityview/template/after',
-			$view_id_output = function ( $context ) {
-				printf( '<input type="hidden" class="gravityview-view-id" value="%d">', $context->view->ID );
-			}
-		);
+			add_action(
+				'gravityview/template/after',
+				$view_id_output = function ( $context ) {
+					printf( '<input type="hidden" class="gravityview-view-id" value="%d">', $context->view->ID );
+				}
+			);
 
-		ob_start();
-		$template->render();
+			ob_start();
+			$template->render();
 
-		remove_action( 'gravityview/template/after', $view_id_output );
-		remove_filter( 'gravityview/template/view/render', $add_anchor_id_filter );
-		remove_filter( 'gravityview/widget/search/form/action', $add_search_action_filter );
+			remove_action( 'gravityview/template/after', $view_id_output );
+			remove_filter( 'gravityview/template/view/render', $add_anchor_id_filter );
+			remove_filter( 'gravityview/widget/search/form/action', $add_search_action_filter );
 
-		\GV\Mocks\Legacy_Context::pop();
+			\GV\Mocks\Legacy_Context::pop();
 
-		$output = ob_get_clean();
+			$output = ob_get_clean();
 
-		\GV\View::pop_rendering();
-
-		return $output;
+			return $output;
+		} finally {
+			// Ensure the rendering stack is always popped, even if an error occurs.
+			\GV\View::pop_rendering();
+		}
 	}
 }

--- a/future/includes/class-gv-renderer-view.php
+++ b/future/includes/class-gv-renderer-view.php
@@ -174,8 +174,8 @@ class View_Renderer extends Renderer {
 			 */
 			$parameters = $view->settings->as_atts();
 			if ( ! empty( $parameters['sort_field'] ) && is_array( $parameters['sort_field'] ) ) {
-				$has_multisort            = true;
 				$parameters['sort_field'] = reset( $parameters['sort_field'] );
+
 				if ( ! empty( $parameters['sort_direction'] ) && is_array( $parameters['sort_direction'] ) ) {
 					$parameters['sort_direction'] = reset( $parameters['sort_direction'] );
 				}

--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -977,7 +977,7 @@ class View implements \ArrayAccess {
 			return ! empty( self::$rendering_stack );
 		}
 
-		return in_array( $view_id, self::$rendering_stack );
+		return in_array( $view_id, self::$rendering_stack, true );
 	}
 
 	/**
@@ -1037,7 +1037,7 @@ class View implements \ArrayAccess {
 	 * @return bool True if the View is embedded within another View.
 	 */
 	public static function is_embedded_view( $view_id ) {
-		return in_array( $view_id, self::$rendering_stack ) && $view_id !== self::$rendering_stack[0];
+		return in_array( $view_id, self::$rendering_stack, true ) && $view_id !== self::$rendering_stack[0];
 	}
 
 	/**

--- a/future/includes/class-gv-view.php
+++ b/future/includes/class-gv-view.php
@@ -95,6 +95,15 @@ class View implements \ArrayAccess {
 	private static $cache = array();
 
 	/**
+	 * @var array Stack to track currently rendering Views (for embedded View detection).
+	 *
+	 * @since TBD
+	 *
+	 * @internal
+	 */
+	private static $rendering_stack = array();
+
+	/**
 	 * @var \GV\Join[] The joins for all sources in this view.
 	 *
 	 * @api
@@ -924,6 +933,160 @@ class View implements \ArrayAccess {
 	 */
 	public static function exists( $view ) {
 		return self::POST_TYPE == get_post_type( $view );
+	}
+
+	/**
+	 * Starts tracking that a View is being rendered.
+	 *
+	 * @interal
+	 *
+	 * @since TBD
+	 *
+	 * @param int $view_id The View ID being rendered.
+	 */
+	public static function push_rendering( $view_id ) {
+		self::$rendering_stack[] = $view_id;
+	}
+
+	/**
+	 * Stops tracking that a View is being rendered
+	 *
+	 * @interal
+	 *
+	 * @since TBD
+	 *
+	 * @return int|null The View ID that was being rendered, or null if stack was empty.
+	 */
+	public static function pop_rendering() {
+		return array_pop( self::$rendering_stack );
+	}
+
+	/**
+	 * Checks if a View is currently being rendered (embedded View detection).
+	 *
+	 * @interal
+	 *
+	 * @since TBD
+	 *
+	 * @param int|null $view_id If provided, check if this specific View is being rendered. If null, check if any view is being rendered.
+	 *
+	 * @return bool True if the View (or any View) is being rendered.
+	 */
+	public static function is_rendering( $view_id = null ) {
+		if ( null === $view_id ) {
+			return ! empty( self::$rendering_stack );
+		}
+
+		return in_array( $view_id, self::$rendering_stack );
+	}
+
+	/**
+	 * Returns the currently rendering View ID (the most recent one).
+	 *
+	 * @interal
+	 *
+	 * @since TBD
+	 *
+	 * @return int|null The View ID currently being rendered, or null if none.
+	 */
+	public static function get_current_rendering() {
+		if ( empty( self::$rendering_stack ) ) {
+			return null;
+		}
+
+		return end( self::$rendering_stack );
+	}
+
+	/**
+	 * Returns all currently rendering View IDs.
+	 *
+	 * @interal
+	 *
+	 * @since TBD
+	 *
+	 * @return array Array of View IDs in rendering order (oldest to newest).
+	 */
+	public static function get_rendering_stack() {
+		return self::$rendering_stack;
+	}
+
+	/**
+	 * Checks if View is the primary (first) rendering View.
+	 *
+	 * @interal
+	 *
+	 * @since TBD
+	 *
+	 * @param int $view_id The View ID to check
+	 *
+	 * @return bool True if the View is the primary rendering View.
+	 */
+	public static function is_primary_view( $view_id ) {
+		return ! empty( self::$rendering_stack ) && self::$rendering_stack[0] === $view_id;
+	}
+
+	/**
+	 * Checks if View is embedded (not the first in stack).
+	 *
+	 * @interal
+	 *
+	 * @since TBD
+	 *
+	 * @param int $view_id The View ID to check
+	 *
+	 * @return bool True if the View is embedded within another View.
+	 */
+	public static function is_embedded_view( $view_id ) {
+		return in_array( $view_id, self::$rendering_stack ) && $view_id !== self::$rendering_stack[0];
+	}
+
+	/**
+	 * Returns the parent View of an embedded View.
+	 *
+	 * @interal
+	 *
+	 * @since TBD
+	 *
+	 * @param int $view_id The View ID to get parent for.
+	 *
+	 * @return int|null The parent View ID, or null if not embedded or no parent.
+	 */
+	public static function get_parent_view( $view_id ) {
+		$position = array_search( $view_id, self::$rendering_stack );
+
+		if ( $position > 0 ) {
+			return self::$rendering_stack[ $position - 1 ];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the rendering depth of a View (how many levels deep it's nested).
+	 *
+	 * @interal
+	 *
+	 * @since TBD
+	 *
+	 * @param int $view_id The View ID to check
+	 *
+	 * @return int|false The depth (0 for primary, 1+ for nested), or false if not rendering.
+	 */
+	public static function get_rendering_depth( $view_id ) {
+		return array_search( $view_id, self::$rendering_stack );
+	}
+
+	/**
+	 * Resets the rendering stack.
+	 *
+	 * @internal
+	 *
+	 * @since TBD
+	 *
+	 * @internal
+	 */
+	public static function reset_rendering_stack() {
+		self::$rendering_stack = [];
 	}
 
 	/**

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -1455,7 +1455,7 @@ class GravityView_Widget_Search extends \GV\Widget {
 
 			// For embedded Views with no searchable fields, allow all fields.
 			if ( ! $is_embedded_view || ! empty( $searchable_fields ) ) {
-				if ( ! in_array( 'search_all', $searchable_fields ) && ! in_array( $field_id, $searchable_fields ) ) {
+				if ( ! in_array( 'search_all', $searchable_fields, true ) && ! in_array( $field_id, $searchable_fields, true ) ) {
 					return false;
 				}
 			}

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -77,8 +77,6 @@ class GravityView_Widget_Search extends \GV\Widget {
 			// frontend - filter entries
 			add_filter( 'gravityview_fe_search_criteria', [ $this, 'filter_entries' ], 10, 3 );
 
-			add_action( 'gravityview/view/query', [ $this, 'gf_query_filter' ], 10, 3 );
-
 			// frontend - add template path
 			add_filter( 'gravityview_template_paths', [ $this, 'add_template_path' ] );
 

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -951,6 +951,16 @@ class GravityView_Widget_Search extends \GV\Widget {
 	 * @param \GV\Request $request The request object
 	 */
 	public function gf_query_filter( &$query, $view, $request ) {
+		// Don't apply search filters when viewing a single entry.
+		if ( $request && $request->is_entry() ) {
+			return;
+		}
+
+		// When $request is null, check if we're in a single entry context.
+		if ( ! $request && gravityview()->request && gravityview()->request->is_entry() ) {
+			return;
+		}
+
 		/**
 		 * This is a shortcut to get all the needed search criteria.
 		 * We feed these into an new GF_Query and tack them onto the current object.

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,7 @@ Beautifully display your Gravity Forms entries. Learn more on [gravitykit.com](h
 * The Export widget not working when Views were filtered to show entries created by the currently logged-in user.
 * Fields linked to single entry layouts are now exported as plain text values, not hyperlinks, when using direct CSV/TSV export URLs.
 * Featured entries in the Layout Builder template now display with their intended styling.
+* Single Entry pages not rendering when search filter parameters were present in the URL.
 
 #### 💻 Developer Updates
 * Added a `gv-template-{type}` class to the outer containers of Layout Builder, List, and Table templates, enabling easier custom JS and CSS targeting.

--- a/tests/unit-tests/GV/GV_View_Tracking_Test.php
+++ b/tests/unit-tests/GV/GV_View_Tracking_Test.php
@@ -1,0 +1,670 @@
+<?php
+
+use GV\Mock_Request;
+use GV\View;
+use GV\View_Renderer;
+use GV\View_Settings;
+
+defined( 'DOING_GRAVITYVIEW_TESTS' ) || exit;
+
+/**
+ * Tests for the View rendering tracking API.
+ *
+ * @group gv_view_tracking
+ * @since TBD
+ */
+class GV_View_Tracking_Test extends GV_UnitTestCase {
+	/**
+	 * Resets the rendering stack before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		View::reset_rendering_stack();
+	}
+
+	/**
+	 * Cleans up after each test.
+	 */
+	public function tearDown(): void {
+		View::reset_rendering_stack();
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers View::push_rendering
+	 * @covers View::pop_rendering
+	 * @covers View::is_rendering
+	 */
+	public function test_basic_push_pop_rendering() {
+		// Initially, no Views should be rendering.
+		$this->assertFalse( View::is_rendering() );
+		$this->assertFalse( View::is_rendering( 100 ) );
+
+		// Push a View onto the stack.
+		View::push_rendering( 100 );
+		$this->assertTrue( View::is_rendering() );
+		$this->assertTrue( View::is_rendering( 100 ) );
+		$this->assertFalse( View::is_rendering( 200 ) );
+
+		// Push another View.
+		View::push_rendering( 200 );
+		$this->assertTrue( View::is_rendering() );
+		$this->assertTrue( View::is_rendering( 100 ) );
+		$this->assertTrue( View::is_rendering( 200 ) );
+
+		// Pop the second View.
+		$popped = View::pop_rendering();
+		$this->assertEquals( 200, $popped );
+		$this->assertTrue( View::is_rendering() );
+		$this->assertTrue( View::is_rendering( 100 ) );
+		$this->assertFalse( View::is_rendering( 200 ) );
+
+		// Pop the first View.
+		$popped = View::pop_rendering();
+		$this->assertEquals( 100, $popped );
+		$this->assertFalse( View::is_rendering() );
+		$this->assertFalse( View::is_rendering( 100 ) );
+
+		// Pop from empty stack should return null.
+		$popped = View::pop_rendering();
+		$this->assertNull( $popped );
+	}
+
+	/**
+	 * @covers View::get_current_rendering
+	 */
+	public function test_get_current_rendering() {
+		// No current rendering when stack is empty.
+		$this->assertNull( View::get_current_rendering() );
+
+		// Push first View.
+		View::push_rendering( 100 );
+		$this->assertEquals( 100, View::get_current_rendering() );
+
+		// Push second View - should be current.
+		View::push_rendering( 200 );
+		$this->assertEquals( 200, View::get_current_rendering() );
+
+		// Push third View.
+		View::push_rendering( 300 );
+		$this->assertEquals( 300, View::get_current_rendering() );
+
+		// Pop third View - second should be current.
+		View::pop_rendering();
+		$this->assertEquals( 200, View::get_current_rendering() );
+
+		// Pop second View - first should be current.
+		View::pop_rendering();
+		$this->assertEquals( 100, View::get_current_rendering() );
+
+		// Pop first View - no current.
+		View::pop_rendering();
+		$this->assertNull( View::get_current_rendering() );
+	}
+
+	/**
+	 * @covers View::get_rendering_stack
+	 */
+	public function test_get_rendering_stack() {
+		// Empty stack initially.
+		$this->assertEquals( [], View::get_rendering_stack() );
+
+		// Add Views.
+		View::push_rendering( 100 );
+		$this->assertEquals( [ 100 ], View::get_rendering_stack() );
+
+		View::push_rendering( 200 );
+		$this->assertEquals( [ 100, 200 ], View::get_rendering_stack() );
+
+		View::push_rendering( 300 );
+		$this->assertEquals( [ 100, 200, 300 ], View::get_rendering_stack() );
+
+		// Remove a View.
+		View::pop_rendering();
+		$this->assertEquals( [ 100, 200 ], View::get_rendering_stack() );
+	}
+
+	/**
+	 * @covers View::is_primary_view
+	 */
+	public function test_is_primary_view() {
+		// No primary View when stack is empty.
+		$this->assertFalse( View::is_primary_view( 100 ) );
+
+		// First View is primary.
+		View::push_rendering( 100 );
+		$this->assertTrue( View::is_primary_view( 100 ) );
+		$this->assertFalse( View::is_primary_view( 200 ) );
+
+		// Second View is not primary.
+		View::push_rendering( 200 );
+		$this->assertTrue( View::is_primary_view( 100 ) );
+		$this->assertFalse( View::is_primary_view( 200 ) );
+
+		// Third View is not primary.
+		View::push_rendering( 300 );
+		$this->assertTrue( View::is_primary_view( 100 ) );
+		$this->assertFalse( View::is_primary_view( 200 ) );
+		$this->assertFalse( View::is_primary_view( 300 ) );
+	}
+
+	/**
+	 * @covers View::is_embedded_view
+	 */
+	public function test_is_embedded_view() {
+		// No embedded View when stack is empty.
+		$this->assertFalse( View::is_embedded_view( 100 ) );
+
+		// First View is not embedded.
+		View::push_rendering( 100 );
+		$this->assertFalse( View::is_embedded_view( 100 ) );
+
+		// Second View is embedded.
+		View::push_rendering( 200 );
+		$this->assertFalse( View::is_embedded_view( 100 ) );
+		$this->assertTrue( View::is_embedded_view( 200 ) );
+
+		// Third View is also embedded.
+		View::push_rendering( 300 );
+		$this->assertFalse( View::is_embedded_view( 100 ) );
+		$this->assertTrue( View::is_embedded_view( 200 ) );
+		$this->assertTrue( View::is_embedded_view( 300 ) );
+
+		// Non-rendering View is not embedded.
+		$this->assertFalse( View::is_embedded_view( 400 ) );
+	}
+
+	/**
+	 * @covers View::get_parent_view
+	 */
+	public function test_get_parent_view() {
+		// No parent when not in stack.
+		$this->assertNull( View::get_parent_view( 100 ) );
+
+		// Primary View has no parent.
+		View::push_rendering( 100 );
+		$this->assertNull( View::get_parent_view( 100 ) );
+
+		// Second View's parent is first View.
+		View::push_rendering( 200 );
+		$this->assertNull( View::get_parent_view( 100 ) );
+		$this->assertEquals( 100, View::get_parent_view( 200 ) );
+
+		// Third View's parent is second View.
+		View::push_rendering( 300 );
+		$this->assertNull( View::get_parent_view( 100 ) );
+		$this->assertEquals( 100, View::get_parent_view( 200 ) );
+		$this->assertEquals( 200, View::get_parent_view( 300 ) );
+
+		// Non-rendering View has no parent.
+		$this->assertNull( View::get_parent_view( 400 ) );
+	}
+
+	/**
+	 * @covers View::get_rendering_depth
+	 */
+	public function test_get_rendering_depth() {
+		// False when not in stack.
+		$this->assertFalse( View::get_rendering_depth( 100 ) );
+
+		// First View has depth 0.
+		View::push_rendering( 100 );
+		$this->assertEquals( 0, View::get_rendering_depth( 100 ) );
+
+		// Second View has depth 1.
+		View::push_rendering( 200 );
+		$this->assertEquals( 0, View::get_rendering_depth( 100 ) );
+		$this->assertEquals( 1, View::get_rendering_depth( 200 ) );
+
+		// Third View has depth 2.
+		View::push_rendering( 300 );
+		$this->assertEquals( 0, View::get_rendering_depth( 100 ) );
+		$this->assertEquals( 1, View::get_rendering_depth( 200 ) );
+		$this->assertEquals( 2, View::get_rendering_depth( 300 ) );
+
+		// Non-rendering View returns false.
+		$this->assertFalse( View::get_rendering_depth( 400 ) );
+	}
+
+	/**
+	 * @covers View::reset_rendering_stack
+	 */
+	public function test_reset_rendering_stack() {
+		// Add some Views.
+		View::push_rendering( 100 );
+		View::push_rendering( 200 );
+		View::push_rendering( 300 );
+
+		// Verify they're in the stack.
+		$this->assertTrue( View::is_rendering( 100 ) );
+		$this->assertTrue( View::is_rendering( 200 ) );
+		$this->assertTrue( View::is_rendering( 300 ) );
+		$this->assertEquals( [ 100, 200, 300 ], View::get_rendering_stack() );
+
+		// Reset the stack.
+		View::reset_rendering_stack();
+
+		// Verify stack is empty.
+		$this->assertFalse( View::is_rendering() );
+		$this->assertFalse( View::is_rendering( 100 ) );
+		$this->assertFalse( View::is_rendering( 200 ) );
+		$this->assertFalse( View::is_rendering( 300 ) );
+		$this->assertEquals( [], View::get_rendering_stack() );
+		$this->assertNull( View::get_current_rendering() );
+	}
+
+	/**
+	 * Tests complex nested rendering scenario.
+	 */
+	public function test_complex_nested_rendering() {
+		// Simulate a complex nested rendering scenario:
+		// View 100 renders View 200 which renders View 300.
+		// Then View 200 also renders View 400.
+
+		// Start rendering main View.
+		View::push_rendering( 100 );
+		$this->assertTrue( View::is_primary_view( 100 ) );
+		$this->assertFalse( View::is_embedded_view( 100 ) );
+
+		// Main View starts rendering embedded View 200.
+		View::push_rendering( 200 );
+		$this->assertTrue( View::is_embedded_view( 200 ) );
+		$this->assertEquals( 100, View::get_parent_view( 200 ) );
+
+		// View 200 starts rendering embedded View 300.
+		View::push_rendering( 300 );
+		$this->assertTrue( View::is_embedded_view( 300 ) );
+		$this->assertEquals( 200, View::get_parent_view( 300 ) );
+		$this->assertEquals( 2, View::get_rendering_depth( 300 ) );
+
+		// View 300 finishes.
+		View::pop_rendering();
+		$this->assertFalse( View::is_rendering( 300 ) );
+
+		// View 200 now starts rendering View 400.
+		View::push_rendering( 400 );
+		$this->assertTrue( View::is_embedded_view( 400 ) );
+		$this->assertEquals( 200, View::get_parent_view( 400 ) );
+		$this->assertEquals( 2, View::get_rendering_depth( 400 ) );
+
+		// Check current state.
+		$this->assertEquals( [ 100, 200, 400 ], View::get_rendering_stack() );
+		$this->assertEquals( 400, View::get_current_rendering() );
+
+		// Unwind the stack.
+		View::pop_rendering(); // 400 finishes.
+		$this->assertEquals( 200, View::get_current_rendering() );
+
+		View::pop_rendering(); // 200 finishes.
+		$this->assertEquals( 100, View::get_current_rendering() );
+
+		View::pop_rendering(); // 100 finishes.
+		$this->assertNull( View::get_current_rendering() );
+		$this->assertFalse( View::is_rendering() );
+	}
+
+	/**
+	 * Test View_Renderer integration with actual rendering
+	 * This test verifies that the View_Renderer properly manages the rendering stack
+	 */
+	public function test_view_renderer_integration() {
+		$form = $this->factory->form->import_and_get( 'simple.json' );
+
+		$this->factory->entry->create_and_get( [
+			'form_id' => $form['id'],
+			'status'  => 'active',
+			'1'       => 'Test entry content',
+		] );
+
+		$settings                       = View_Settings::defaults();
+		$settings['show_only_approved'] = 0;
+
+		$view_post = $this->factory->view->create_and_get( [
+			'form_id'     => $form['id'],
+			'template_id' => 'table',
+			'fields'      => [
+				'directory_table-columns' => [
+					wp_generate_password( 4, false ) => [
+						'id'    => '1',
+						'label' => 'Text',
+					],
+				],
+			],
+			'settings'    => $settings,
+		] );
+
+		$view = View::from_post( $view_post );
+		$this->assertInstanceOf( View::class, $view );
+
+		// Set up the request.
+		gravityview()->request                     = new Mock_Request();
+		gravityview()->request->returns['is_view'] = $view;
+
+		$renderer = new View_Renderer();
+
+		// Initially, nothing should be rendering.
+		$this->assertFalse( View::is_rendering( $view->ID ) );
+		$this->assertNull( View::get_current_rendering() );
+
+		// Hook into the render process to verify tracking.
+		$tracking_checks = [];
+		add_action( 'gravityview/template/before', function ( $context ) use ( &$tracking_checks, $view ) {
+			$tracking_checks['before'] = [
+				'is_rendering' => View::is_rendering( $view->ID ),
+				'current'      => View::get_current_rendering(),
+				'is_primary'   => View::is_primary_view( $view->ID ),
+				'is_embedded'  => View::is_embedded_view( $view->ID ),
+			];
+		} );
+
+		add_action( 'gravityview/template/after', function ( $context ) use ( &$tracking_checks, $view ) {
+			$tracking_checks['after'] = [
+				'is_rendering' => View::is_rendering( $view->ID ),
+				'current'      => View::get_current_rendering(),
+				'is_primary'   => View::is_primary_view( $view->ID ),
+				'is_embedded'  => View::is_embedded_view( $view->ID ),
+			];
+		} );
+
+		$output = $renderer->render( $view );
+
+		// After rendering, stack should be empty.
+		$this->assertFalse( View::is_rendering( $view->ID ) );
+		$this->assertNull( View::get_current_rendering() );
+
+		// Verify tracking was correct during render.
+		$this->assertArrayHasKey( 'before', $tracking_checks );
+		$this->assertTrue( $tracking_checks['before']['is_rendering'] );
+		$this->assertEquals( $view->ID, $tracking_checks['before']['current'] );
+		$this->assertTrue( $tracking_checks['before']['is_primary'] );
+		$this->assertFalse( $tracking_checks['before']['is_embedded'] );
+
+		$this->assertArrayHasKey( 'after', $tracking_checks );
+		$this->assertTrue( $tracking_checks['after']['is_rendering'] );
+		$this->assertEquals( $view->ID, $tracking_checks['after']['current'] );
+
+		// Verify the View actually rendered.
+		$this->assertStringContainsString( 'Test entry content', $output );
+	}
+
+	/**
+	 * Tests embedded View rendering with tracking.
+	 * This tests that Views embedded via [gravityview] shortcode are properly tracked.
+	 */
+	public function test_embedded_view_rendering_tracking() {
+		$form1 = $this->factory->form->import_and_get( 'simple.json' );
+		$form2 = $this->factory->form->import_and_get( 'simple.json' );
+
+		$this->factory->entry->create_and_get( [
+			'form_id' => $form1['id'],
+			'status'  => 'active',
+			'1'       => 'Entry in OUTER View form',
+		] );
+
+		$this->factory->entry->create_and_get( [
+			'form_id' => $form2['id'],
+			'status'  => 'active',
+			'1'       => 'Entry in INNER View form',
+		] );
+
+		$settings                       = View_Settings::defaults();
+		$settings['show_only_approved'] = 0;
+
+		// Create the inner View that will be embedded.
+		$inner_view_post = $this->factory->view->create_and_get( [
+			'form_id'     => $form2['id'],
+			'template_id' => 'table',
+			'fields'      => [
+				'directory_table-columns' => [
+					wp_generate_password( 4, false ) => [
+						'id'    => '1',
+						'label' => 'Text from inner View',
+					],
+				],
+			],
+			'settings'    => $settings,
+		] );
+
+		// Create the outer View with custom content field using [gravityview] shortcode.
+		$outer_view_post = $this->factory->view->create_and_get( [
+			'form_id'     => $form1['id'],
+			'template_id' => 'table',
+			'fields'      => [
+				'directory_table-columns' => [
+					wp_generate_password( 4, false ) => [
+						'id'    => '1',
+						'label' => 'Text from outer View',
+					],
+					wp_generate_password( 4, false ) => [
+						'id'      => 'custom',
+						'content' => '[gravityview id="' . $inner_view_post->ID . '"]',
+					],
+				],
+			],
+			'settings'    => $settings,
+		] );
+
+		$inner_view = View::from_post( $inner_view_post );
+		$outer_view = View::from_post( $outer_view_post );
+
+		// Set up the request for directory View (which will render the embedded View via shortcode).
+		$request                     = new Mock_Request();
+		$request->returns['is_view'] = $outer_view;
+
+		// Track what happens during rendering.
+		$render_tracking = [];
+
+		add_action( 'gravityview/template/before', function ( $context ) use ( &$render_tracking ) {
+			$view_id                 = $context->view->ID;
+			$key                     = 'template_before_' . $view_id;
+			$render_tracking[ $key ] = [
+				'view_id'      => $view_id,
+				'stack'        => View::get_rendering_stack(),
+				'is_rendering' => View::is_rendering( $view_id ),
+				'is_primary'   => View::is_primary_view( $view_id ),
+				'is_embedded'  => View::is_embedded_view( $view_id ),
+				'parent'       => View::get_parent_view( $view_id ),
+				'depth'        => View::get_rendering_depth( $view_id ),
+			];
+		} );
+
+		// Render the outer View (which contains the embedded View via [gravityview] shortcode).
+		$renderer = new View_Renderer();
+
+		// Initially nothing should be rendering.
+		$this->assertFalse( View::is_rendering() );
+
+		$output = $renderer->render( $outer_view, $request );
+
+		// After rendering, stack should be empty.
+		$this->assertFalse( View::is_rendering() );
+		$this->assertEmpty( View::get_rendering_stack() );
+
+		// Verify the outer View was tracked.
+		$outer_key = 'template_before_' . $outer_view->ID;
+		$this->assertArrayHasKey( $outer_key, $render_tracking, 'Outer View should have been tracked during rendering' );
+		$this->assertTrue( $render_tracking[ $outer_key ]['is_rendering'] );
+		$this->assertTrue( $render_tracking[ $outer_key ]['is_primary'] );
+		$this->assertFalse( $render_tracking[ $outer_key ]['is_embedded'] );
+		$this->assertNull( $render_tracking[ $outer_key ]['parent'] );
+		$this->assertEquals( 0, $render_tracking[ $outer_key ]['depth'] );
+
+		// Verify output contains content from outer View.
+		$this->assertStringContainsString( 'Entry in OUTER View form', $output, 'Output should contain content from outer View entries' );
+
+		// CRITICAL: Verify that the inner View was actually rendered and tracked.
+		$inner_key = 'template_before_' . $inner_view->ID;
+		$this->assertArrayHasKey( $inner_key, $render_tracking, 'Inner View should have been tracked during rendering - this means the embedded View was actually rendered' );
+
+		// If inner View was tracked, verify it was tracked correctly as embedded.
+		$this->assertTrue( $render_tracking[ $inner_key ]['is_rendering'], 'Inner View should be marked as rendering when tracked' );
+		$this->assertFalse( $render_tracking[ $inner_key ]['is_primary'], 'Inner View should not be primary' );
+		$this->assertTrue( $render_tracking[ $inner_key ]['is_embedded'], 'Inner View should be marked as embedded' );
+		$this->assertEquals( $outer_view->ID, $render_tracking[ $inner_key ]['parent'], 'Inner View parent should be outer View' );
+		$this->assertEquals( 1, $render_tracking[ $inner_key ]['depth'], 'Inner View should have depth 1' );
+
+		// The stack should show both Views when inner is rendering.
+		$this->assertContains( $outer_view->ID, $render_tracking[ $inner_key ]['stack'], 'Outer View should be in stack when inner View renders' );
+		$this->assertContains( $inner_view->ID, $render_tracking[ $inner_key ]['stack'], 'Inner View should be in stack when it renders' );
+
+		// CRITICAL: Verify output contains content from embedded View.
+		$this->assertStringContainsString( 'Entry in INNER View form', $output, 'Output should contain content from embedded View entries - this proves the embedded View actually rendered' );
+	}
+
+	/**
+	 * Tests multiple nested Views (View A contains View B which contains View C)
+	 */
+	public function test_deeply_nested_view_rendering() {
+		$form1 = $this->factory->form->import_and_get( 'simple.json' );
+		$form2 = $this->factory->form->import_and_get( 'simple.json' );
+		$form3 = $this->factory->form->import_and_get( 'simple.json' );
+
+		$this->factory->entry->create_and_get( [
+			'form_id' => $form1['id'],
+			'status'  => 'active',
+			'1'       => 'Content from VIEW A form',
+		] );
+
+		$this->factory->entry->create_and_get( [
+			'form_id' => $form2['id'],
+			'status'  => 'active',
+			'1'       => 'Content from VIEW B form',
+		] );
+
+		$this->factory->entry->create_and_get( [
+			'form_id' => $form3['id'],
+			'status'  => 'active',
+			'1'       => 'Content from VIEW C form',
+		] );
+
+		$settings                       = View_Settings::defaults();
+		$settings['show_only_approved'] = 0;
+
+		// Create View C (innermost).
+		$view_c_post = $this->factory->view->create_and_get( [
+			'form_id'     => $form3['id'],
+			'template_id' => 'table',
+			'fields'      => [
+				'directory_table-columns' => [
+					wp_generate_password( 4, false ) => [
+						'id'    => '1',
+						'label' => 'View C Content',
+					],
+				],
+			],
+			'settings'    => $settings,
+		] );
+
+		// Create View B (contains View C) using custom content field with shortcode.
+		$view_b_post = $this->factory->view->create_and_get( [
+			'form_id'     => $form2['id'],
+			'template_id' => 'table',
+			'fields'      => [
+				'directory_table-columns' => [
+					wp_generate_password( 4, false ) => [
+						'id'    => '1',
+						'label' => 'View B Content',
+					],
+					wp_generate_password( 4, false ) => [
+						'id'      => 'custom',
+						'content' => '[gravityview id="' . $view_c_post->ID . '"]',
+					],
+				],
+			],
+			'settings'    => $settings,
+		] );
+
+		// Create View A (contains View B) using custom content field with shortcode.
+		$view_a_post = $this->factory->view->create_and_get( [
+			'form_id'     => $form1['id'],
+			'template_id' => 'table',
+			'fields'      => [
+				'directory_table-columns' => [
+					wp_generate_password( 4, false ) => [
+						'id'    => '1',
+						'label' => 'View A Content',
+					],
+					wp_generate_password( 4, false ) => [
+						'id'      => 'custom',
+						'content' => '[gravityview id="' . $view_b_post->ID . '"]',
+					],
+				],
+			],
+			'settings'    => $settings,
+		] );
+
+		$view_a = View::from_post( $view_a_post );
+		$view_b = View::from_post( $view_b_post );
+		$view_c = View::from_post( $view_c_post );
+
+		// Track all rendered Views and their rendering details.
+		$render_tracking = [];
+		$max_depth       = 0;
+		$max_stack_size  = 0;
+
+		add_action( 'gravityview/template/before', function ( $context ) use ( &$render_tracking, &$max_depth, &$max_stack_size ) {
+			$view_id        = $context->view->ID;
+			$stack          = View::get_rendering_stack();
+			$max_stack_size = max( $max_stack_size, count( $stack ) );
+
+			$depth = View::get_rendering_depth( $view_id );
+			if ( $depth !== false ) {
+				$max_depth = max( $max_depth, $depth );
+			}
+
+			$render_tracking[ $view_id ] = [
+				'view_id'      => $view_id,
+				'stack'        => $stack,
+				'is_rendering' => View::is_rendering( $view_id ),
+				'is_primary'   => View::is_primary_view( $view_id ),
+				'is_embedded'  => View::is_embedded_view( $view_id ),
+				'parent'       => View::get_parent_view( $view_id ),
+				'depth'        => $depth,
+			];
+		} );
+
+		$request                     = new Mock_Request();
+		$request->returns['is_view'] = $view_a;
+
+		// Render View A (which should recursively render B and C).
+		$renderer = new View_Renderer();
+		$output   = $renderer->render( $view_a, $request );
+
+		// After rendering, stack should be empty.
+		$this->assertFalse( View::is_rendering(), 'No Views should be rendering after completion' );
+		$this->assertEmpty( View::get_rendering_stack(), 'Rendering stack should be empty after completion' );
+
+		// Verify View A was tracked.
+		$this->assertArrayHasKey( $view_a->ID, $render_tracking, 'View A should have been tracked' );
+		$this->assertTrue( $render_tracking[ $view_a->ID ]['is_primary'], 'View A should be primary' );
+		$this->assertFalse( $render_tracking[ $view_a->ID ]['is_embedded'], 'View A should not be embedded' );
+		$this->assertEquals( 0, $render_tracking[ $view_a->ID ]['depth'], 'View A should have depth 0' );
+
+		// Verify View A content is in output.
+		$this->assertStringContainsString( 'Content from VIEW A form', $output, 'Output should contain View A content' );
+
+		// CRITICAL: Verify View B was tracked (embedded in A).
+		$this->assertArrayHasKey( $view_b->ID, $render_tracking, 'View B should have been tracked - this means B was actually rendered inside A' );
+		$this->assertFalse( $render_tracking[ $view_b->ID ]['is_primary'], 'View B should not be primary' );
+		$this->assertTrue( $render_tracking[ $view_b->ID ]['is_embedded'], 'View B should be embedded' );
+		$this->assertEquals( $view_a->ID, $render_tracking[ $view_b->ID ]['parent'], 'View B parent should be View A' );
+		$this->assertEquals( 1, $render_tracking[ $view_b->ID ]['depth'], 'View B should have depth 1' );
+
+		// Verify View B content is in output.
+		$this->assertStringContainsString( 'Content from VIEW B form', $output, 'Output should contain View B content - this proves B was actually rendered' );
+
+		// CRITICAL: Verify View C was tracked (embedded in B).
+		$this->assertArrayHasKey( $view_c->ID, $render_tracking, 'View C should have been tracked - this means C was actually rendered inside B' );
+		$this->assertFalse( $render_tracking[ $view_c->ID ]['is_primary'], 'View C should not be primary' );
+		$this->assertTrue( $render_tracking[ $view_c->ID ]['is_embedded'], 'View C should be embedded' );
+		$this->assertEquals( $view_b->ID, $render_tracking[ $view_c->ID ]['parent'], 'View C parent should be View B' );
+		$this->assertEquals( 2, $render_tracking[ $view_c->ID ]['depth'], 'View C should have depth 2' );
+
+		// Verify View C content is in output.
+		$this->assertStringContainsString( 'Content from VIEW C form', $output, 'Output should contain View C content - this proves C was actually rendered' );
+
+		// Verify nesting levels.
+		$this->assertEquals( 2, $max_depth, 'Maximum depth should be 2 for three-level nesting (A->B->C)' );
+		$this->assertEquals( 3, $max_stack_size, 'Maximum stack size should be 3 when all three Views are rendering simultaneously' );
+	}
+}

--- a/tests/unit-tests/GravityView_Widget_Search_Test.php
+++ b/tests/unit-tests/GravityView_Widget_Search_Test.php
@@ -2180,4 +2180,185 @@ class GravityView_Widget_Search_Test extends GV_UnitTestCase {
 		remove_all_filters( 'gravityview/widgets/search/datepicker/format' );
 		$_GET = array();
 	}
+
+	/**
+	 * Tests filtering of Views embedded in Single Entry layout with actual rendering.
+	 *
+	 * @covers GravityView_Widget_Search::gf_query_filter()
+	 * @covers GravityView_Widget_Search::prepare_field_filter()
+	 *
+	 * @since TBD
+	 */
+	public function test_embedded_view_filtering_in_single_entry() {
+		$inner_form = $this->factory->form->create_and_get( array(
+			'fields' => array(
+				array(
+					'id' => 1,
+					'type' => 'text',
+					'label' => 'Name',
+				),
+				array(
+					'id' => 2,
+					'type' => 'text',
+					'label' => 'Category',
+				),
+			),
+		) );
+
+		$this->factory->entry->create_and_get( array(
+			'form_id' => $inner_form['id'],
+			'status' => 'active',
+			'1' => 'Product A',
+			'2' => 'Electronics',
+		) );
+
+		$this->factory->entry->create_and_get( array(
+			'form_id' => $inner_form['id'],
+			'status' => 'active',
+			'1' => 'Product B',
+			'2' => 'Electronics',
+		) );
+
+		$this->factory->entry->create_and_get( array(
+			'form_id' => $inner_form['id'],
+			'status' => 'active',
+			'1' => 'Product C',
+			'2' => 'Furniture',
+		) );
+
+		$inner_view_post = $this->factory->view->create_and_get( array(
+			'form_id' => $inner_form['id'],
+			'template_id' => 'table',
+			'fields' => array(
+				'directory_table-columns' => array(
+					wp_generate_password( 4, false ) => array(
+						'id' => '1',
+						'label' => 'Name',
+					),
+					wp_generate_password( 4, false ) => array(
+						'id' => '2',
+						'label' => 'Category',
+					),
+				),
+			),
+			'settings' => array(
+				'show_only_approved' => 0,
+			),
+		) );
+
+		$outer_form = $this->factory->form->create_and_get();
+		$outer_entry = $this->factory->entry->create_and_get( array(
+			'form_id' => $outer_form['id'],
+			'status' => 'active',
+		) );
+
+		$outer_view_post = $this->factory->view->create_and_get( array(
+			'form_id' => $outer_form['id'],
+			'template_id' => 'table',
+			'fields' => array(
+				'single_table-columns' => array(
+					wp_generate_password( 4, false ) => array(
+						'id' => 'id',
+						'label' => 'Entry ID',
+					),
+					wp_generate_password( 4, false ) => array(
+						'id' => 'custom',
+						'content' => sprintf(
+							'<div class="embedded-view-wrapper">[gravityview id="%d"]</div>',
+							$inner_view_post->ID
+						),
+					),
+				),
+			),
+		) );
+
+		$request = new \GV\Mock_Request();
+
+		$outer_view                   = \GV\View::from_post( $outer_view_post );
+		$request->returns['is_view']  = $outer_view;
+		$request->returns['is_entry'] = \GV\GF_Entry::by_id( $outer_entry['id'] );
+
+		gravityview()->request = $request;
+
+		// Test 1: without filter, all entries should appear in embedded View.
+		$_GET = array();
+		\GV\View::reset_rendering_stack();
+
+		// Verify entries exist before rendering.
+		$inner_entries = GFAPI::get_entries( $inner_form['id'] );
+		$this->assertNotEmpty( $inner_entries, 'Inner form should have entries' );
+		$this->assertCount( 3, $inner_entries, 'Should have exactly 3 entries' );
+
+		$renderer = new \GV\Entry_Renderer();
+		$output = $renderer->render( $request->returns['is_entry'], $outer_view );
+
+		// Debug: check what's in the output.
+		if ( strpos( $output, 'No entries match' ) !== false ) {
+			$this->fail( 'Embedded view shows "No entries match" when no filters applied.' );
+		}
+
+		// Verify single entry renders.
+		$this->assertStringContainsString( 'Entry ID', $output, 'Single entry field label should render' );
+		$this->assertStringContainsString( (string) $outer_entry['id'], $output, 'Single entry ID should render' );
+
+		// Verify embedded view renders with all entries
+		$this->assertStringContainsString( 'embedded-view-wrapper', $output, 'Embedded view wrapper should render' );
+		$this->assertStringContainsString( 'Product A', $output, 'First product should be visible' );
+		$this->assertStringContainsString( 'Product B', $output, 'Second product should be visible' );
+		$this->assertStringContainsString( 'Product C', $output, 'Third product should be visible' );
+		$this->assertStringContainsString( 'Electronics', $output, 'Electronics category should be visible' );
+		$this->assertStringContainsString( 'Furniture', $output, 'Furniture category should be visible' );
+
+		// Test 2: with filter on category field, only matching entries should show.
+		$_GET = array( 'filter_2' => 'Electronics' );
+		\GV\View::reset_rendering_stack();
+
+		$output = $renderer->render( $request->returns['is_entry'], $outer_view );
+
+		// Verify single entry still renders (not affected by filter)
+		$this->assertStringContainsString( 'Entry ID', $output, 'Single entry should still render with filter' );
+		$this->assertStringContainsString( (string) $outer_entry['id'], $output, 'Single entry ID should still render with filter' );
+
+		// Verify embedded view is filtered
+		$this->assertStringContainsString( 'Product A', $output, 'Electronics Product A should be visible' );
+		$this->assertStringContainsString( 'Product B', $output, 'Electronics Product B should be visible' );
+		$this->assertStringNotContainsString( 'Product C', $output, 'Furniture Product C should be filtered out' );
+		$this->assertStringNotContainsString( 'Furniture', $output, 'Furniture category should be filtered out' );
+
+		// Test 3: with filter that matches no entries.
+		$_GET = array( 'filter_2' => 'NonExistentCategory' );
+		\GV\View::reset_rendering_stack();
+
+		$output = $renderer->render( $request->returns['is_entry'], $outer_view );
+
+		// Verify single entry still renders
+		$this->assertStringContainsString( 'Entry ID', $output, 'Single entry should render even with non-matching filter' );
+		$this->assertStringContainsString( (string) $outer_entry['id'], $output, 'Single entry ID should render even with non-matching filter' );
+
+		// Verify embedded view shows no entries
+		$this->assertStringContainsString( 'embedded-view-wrapper', $output, 'Embedded view wrapper should still render' );
+		$this->assertStringNotContainsString( 'Product A', $output, 'No products should match' );
+		$this->assertStringNotContainsString( 'Product B', $output, 'No products should match' );
+		$this->assertStringNotContainsString( 'Product C', $output, 'No products should match' );
+
+		// The embedded View should show "No entries" message.
+		$has_no_results = strpos( $output, 'No entries match' ) !== false ||
+		                   strpos( $output, 'no-results' ) !== false;
+		$this->assertTrue( $has_no_results, 'Embedded view should show no results message when filter matches nothing' );
+
+		// Test 4: Verify main single entry is protected from filters that would affect it.
+		$_GET = array( 'filter_id' => '999999' ); // Filter that would exclude the main entry if applied.
+		\GV\View::reset_rendering_stack();
+
+		$output = $renderer->render( $request->returns['is_entry'], $outer_view );
+
+		// The single entry should STILL render despite filter_id not matching.
+		$this->assertStringContainsString( 'Entry ID', $output, 'Single entry should be protected from filter_id' );
+		$this->assertStringContainsString( (string) $outer_entry['id'], $output, 'Single entry should render regardless of filter_id value' );
+
+		$_GET = array();
+		\GV\View::reset_rendering_stack();
+
+		gravityview()->request = new \GV\Frontend_Request();
+	}
 }


### PR DESCRIPTION
Implements #2464.

This also adds support for filtering Views embedded within Single Entry pages, whether inserted using the shortcode in a Custom Content field or through a GravityView View field.

To test:

* Verify that adding URL filter parameters (for existing or non-existent fields) does not prevent Single Entry pages from rendering.
* Embed another View in the Single Entry layout and confirm that filtering works both when accessing the View directly and when it is embedded in a page or post.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added rendering-context tracking to detect primary vs embedded views and handle nested rendering reliably.

- Enhancements
  - Improved embedded-view filtering and shortcode handling so embedded views can apply filters more flexibly while preserving main-view behavior.

- Bug Fixes
  - Fixed Single Entry pages failing to render when search parameters were present.

- Tests
  - Added comprehensive unit tests covering rendering tracking, nested/embedded scenarios, and filtering behavior.

- Documentation
  - Updated changelog with the Single Entry rendering fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/9r83i1nn5hhb7b82vcico/gravityview-2.46.1-5ae8ab00a.zip?rlkey=4ymce59qsqgwblc2ny0bl19bm&dl=1) (5ae8ab00a).